### PR TITLE
add dockerfile and compose config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+Data-Storage
+Log-Files
+My-Workspaces
+debug.log
+
+*.db
+
+.git*
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:15-alpine
+WORKDIR /app
+COPY . .
+RUN adduser --disabled-password --no-create-home superalgos
+RUN chown -R superalgos:superalgos /app
+USER superalgos
+EXPOSE 34248
+EXPOSE 18041
+ENTRYPOINT ["node", "run", "noBrowser"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  superalgos:
+    build: .
+    image: superalgos
+    command: ["minMemo"]
+    ports:
+      - '34248:34248'
+      - '18041:18041'
+    volumes:
+      - ./Data-Storage:/app/Data-Storage
+      - ./Log-Files:/app/Log-Files
+      - ./My-Workspaces:/app/My-Workspaces
+    restart: on-failure


### PR DESCRIPTION
A very basic dockerfile and docker-compose config to aid in running the system as a containerized service. Tested on an amd64 server and an odroid c2 arm64 server.  The default run command is set to `node run noBrowser`, and `minMemo` is configured in the docker-compose config as being an optional flag. If you are running on a beefier host, just remove the line from the docker-compose.yml or comment it out. The default ports are exposed and mapped to the same ports on the host. The data and log directories are configured as volume mounts from the local directory.

docker compose basics:

- build with `docker-compose build`
- run with `docker-compose up`, exit with `Ctrl+C`
- check the status of the service with `docker-compose ps`
- run as a daemon in the background with `docker-compose up -d`
- check the logs with `docker-compose logs`
- stop the service with `docker-compose down`

future work:

- add CI (github workflows? harness? circleci? other?) to build containers and push them to a public registry (docker hub? github CR?) after merging to master/dev or when the repo is tagged