### PR TITLE
Bug Fix for Announcements + Browser Type / Version Check

### DIFF
--- a/Projects/Superalgos/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/TradingStages.js
+++ b/Projects/Superalgos/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/TradingStages.js
@@ -408,12 +408,15 @@ exports.newSuperalgosBotModulesTradingStages = function (processIndex) {
         function runWhenStatusIsOpening() {
             /* Opening Status Procedure */
             if (tradingEngine.tradingCurrent.strategyManageStage.status.value === 'Opening') {
+                let strategy = tradingSystem.tradingStrategies[tradingEngine.tradingCurrent.strategy.index.value]
+                let manageStage = strategy.manageStage
+                
                 /*
                 The system allows the user not to define a Manage Stage, because the Manage Stage is optional.
                 Here we are going to see if that is the case and if it is, we will inmidiatelly consider 
                 the Manage Stage as closed.
                 */
-                if (tradingSystem.tradingStrategies[tradingEngine.tradingCurrent.strategy.index.value].manageStage === undefined) {
+                if (manageStage === undefined) {
                     changeStageStatus('Manage Stage', 'Closed', 'Manage Stage Undefined')
                     changeStageStatus('Close Stage', 'Opening')
                     return
@@ -421,6 +424,7 @@ exports.newSuperalgosBotModulesTradingStages = function (processIndex) {
 
                 /* Now we switch to the Open status. */
                 changeStageStatus('Manage Stage', 'Open')
+                announcementsModuleObject.makeAnnoucements(manageStage)
             }
         }
 

--- a/Projects/Superalgos/UI/Function-Libraries/TradingSessionFunctions.js
+++ b/Projects/Superalgos/UI/Function-Libraries/TradingSessionFunctions.js
@@ -73,11 +73,11 @@ function newSuperalgosFunctionLibraryTradingSessionFunctions() {
             'Situation->Condition->Javascript Code->' +
             'Close Stage->' +
             'Initial Targets->Target Size In Base Asset->Target Size In Quoted Asset->Target Rate->Formula->' +
-            'Announcement->Announcement Formula->Announcement Condition->' +
             'Open Execution->Close Execution->' +
             'Execution Algorithm->Market Buy Order->Market Sell Order->Limit Buy Order->Limit Sell Order->' +
             'Order Rate->Formula->' +
             'Create Order Event->Cancel Order Event->' +
+            'Announcement->Announcement Formula->Announcement Condition->' +
             'Size In Base Asset->Size In Quoted Asset->Position Rate->Formula->' +
             'Situation->Condition->Javascript Code->' +
             'Market Order->Limit Order->' +

--- a/UI/AppPreLoader.js
+++ b/UI/AppPreLoader.js
@@ -40,10 +40,34 @@ function loadSuperalgos() {
     const MODULE_NAME = "App Pre-Loader";
     const INFO_LOG = false;
 
+    let browser = checkBrowserVersion();
     setupHTMLTextArea()
     setupHTMLInput()
     setupHTMLCanvas()
     loadDebugModule()
+
+    if ((browser.name !== "Chrome" && browser.name!=="Safari") || (browser.name === "Chrome" && parseInt(browser.version) < 85) || (browser.name === "Safari" && parseInt(browser.version) < 13)) {
+        alert("Superalgos is officially supported on Google Chrome 85 or Safari 13.1 and above. Your browser version has been detected as potentially beneath this. If you continue you may experience some functionaility issues.\n\nDetected Browser: " + browser.name + "\nVersion: " + browser.version);
+    }
+
+    function checkBrowserVersion () {
+
+        let ua=navigator.userAgent,tem,M=ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
+        if(/trident/i.test(M[1])){
+            tem=/\brv[ :]+(\d+)/g.exec(ua) || [];
+            return {name:'IE',version:(tem[1]||'')};
+        }
+        if(M[1]==='Chrome'){
+            tem=ua.match(/\bOPR|Edge\/(\d+)/)
+            if(tem!=null)   {return {name:'Opera', version:tem[1]};}
+        }
+        M=M[2]? [M[1], M[2]]: [navigator.appName, navigator.appVersion, '-?'];
+        if((tem=ua.match(/version\/(\d+)/i))!=null) {M.splice(1,1,tem[1]);}
+        return {
+            name: M[0],
+            version: M[1]
+        };
+    }
 
     function setupHTMLTextArea() {
         let textArea = document.createElement('textarea');


### PR DESCRIPTION
This bug fix moves the lightingPath entries for Announcements down further so that they are after the Create Order and Cancel Order event (and therefore get correctly added to the Create Order and Cancel Order Event).

It also adds a entry for making an Announcement as we move into the Manage Stage (as there was none but you can create Announcements for the Manage Stage).