### PR TITLE
Bug Fix: Getting Started Tutorial Not Loading

### DIFF
--- a/Projects/Superalgos/UI/Spaces/Tutorial-Space/TutorialSpace.js
+++ b/Projects/Superalgos/UI/Spaces/Tutorial-Space/TutorialSpace.js
@@ -892,7 +892,6 @@ function newSuperalgosTutorialSpace() {
     }
 
     function playTutorial(node) {
-        if (UI.projects.superalgos.spaces.designSpace.workspace.isInitialized !== true ) { return }
 
         PAGE_NUMBER = 0
         TUTORIAL_NAME = node.name
@@ -907,7 +906,6 @@ function newSuperalgosTutorialSpace() {
     }
 
     function resumeTutorial(node) {
-        if (UI.projects.superalgos.spaces.designSpace.workspace.isInitialized !== true ) { return }
 
         navigationStack = []
         node.payload.uiObject.isPlaying = true


### PR DESCRIPTION
At this stage just submitting a quick bug fix so the Getting Started tutorial loads again.

Will add to my TODO list is investigate a better way of checking that the initial indexing has been done and the design space is loaded before the playTutorial function is called. But this will require a bit of a code dive to understand the sequence.