### PR TITLE
WIP: attempt to close the trade when not found

### DIFF
--- a/Projects/Superalgos/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/APIs/ExchangeAPI.js
+++ b/Projects/Superalgos/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/APIs/ExchangeAPI.js
@@ -98,6 +98,13 @@
             tradingSystem.addError([tradingSystemOrder.id, message, docs])
 
             logError("getOrder -> Error = " + err.message);
+            if (err.message === 'coinbasepro NotFound') {
+                logInfo("getOrder -> coinbasepro NotFound, so order is actually closed.")
+                order = {
+                    status: 'NotFound'
+                }
+                return order
+            }
         }
     }
 


### PR DESCRIPTION
work in progress

When cancelling an order at Coinbase, the following `getOrder` will result in `NotFound` because the trade can no longer be accessed. This also means that the `order` object will not have any of the order data, so "synchronization" is not possible.

state of the code:
- The order can be placed
- The order can be cancelled
- `order.status = 'NotFound'` is returned on the following `getOrder`
- internal accounting is attempted to sync the state with the exchange, but the `order` object has no accounting data, resulting in errors when `syncWithExchange()` is executed. If this function is skipped, the next orders attempt to resize to `0` which results in no order being placed.