### PR TITLE
Fixed a typo where 'of' was written instead of 'off'

### DIFF
--- a/Projects/Superalgos/Schemas/Docs-Tutorials/testing-a-trading-idea-the-trigger-stage-072-tutorial-step-take-position-event.json
+++ b/Projects/Superalgos/Schemas/Docs-Tutorials/testing-a-trading-idea-the-trigger-stage-072-tutorial-step-take-position-event.json
@@ -12,7 +12,7 @@
     "paragraphs": [
         {
             "style": "Text",
-            "text": "We mentioned earlier that when either the take position event or the trigger of event validates true, the trigger stage closes."
+            "text": "We mentioned earlier that when either the take position event or the trigger off event validates true, the trigger stage closes."
         },
         {
             "style": "Callout",


### PR DESCRIPTION
In tutorial step 72 of "Testing a Trading Idea - The Trigger Stage" the **trigger off** had a typo. Instead of 'off' it was 'of'