### PR TITLE
Bug Fixes for getOHLCVs from CCXT Library Update

### DIFF
--- a/Projects/Superalgos/TS/Bot-Modules/Sensor-Bot/Exchange-Raw-Data/HistoricOHLCVs.js
+++ b/Projects/Superalgos/TS/Bot-Modules/Sensor-Bot/Exchange-Raw-Data/HistoricOHLCVs.js
@@ -93,6 +93,9 @@
                         if (API.rateLimit !== undefined) {
                             rateLimit = API.rateLimit
                         }
+                        if (API.limit !== undefined) {
+                            limit = API.limit
+                        }
                         if (API.hostname !== undefined) {
                             hostname = API.hostname
                         }
@@ -105,9 +108,6 @@
                                 maxTradesPerFetch = API.maxTradesPerFetch
                             }
                         }
-                    }
-                    if (API.limit !== undefined) {
-                        limit = API.limit
                     }
                 }
             }
@@ -342,11 +342,12 @@
                     let lastOHLCVKey = ''
                     let params = undefined
                     let previousSince
-                    let invalidDate = false
                     let fromDate = new Date(since)
                     let lastDate = new Date()
 
                     while (true) {
+
+                        let invalidDate = false
 
                         /* Reporting we are doing well */
                         function heartBeat(noNewInternalLoop) {


### PR DESCRIPTION
A bit of commentary on this one. 

There have been changes in CCXT behaviour that have changed how Superalgos processes the getOHLCVs function.

On March 10th the CCXT library was updated to latest version: 1.42.67 under https://github.com/Superalgos/Superalgos/commit/ac43839d5d127e53eba900b9e10483ad6091afe3.
NOTE: There have been subsequent updates since then, but this change introduced the changes in behaviour.

### Bug Fix 1: Superalgos used to automatically detect first valid date in market

Prior to the CCXT library update the exchange.getOHLCVs command for CCXT would find the next valid "since" date and continue from this date if the provided since date was invalid (I.E. if you provided "1999-01-01" it would continue on from the first date in the market "2017-08-17").

After this library update CCXT provides OHLCV data for the limit as specified by the since date (I.E. if you specific a limit of 1,000 from "1999-01-01" it will 1,000 OHLCVs from this date and return an empty array I.E. Array(0) as there is no data). 

The commentary on the CCXT documentation advises you to use a since variable of 'undefined'. However, testing this shows that the way CCXT now handles this is that it will go from the **current date time** back the limit amount (I.E. it will go back 1,000 minutes from current date time). This is less than ideal.

Therefore the new function findEarliestDate recursively goes back in 1D intervals until it finds the earliest date with valid data on the Exchange and Market (thereby replicating the old CCXT behaviour).

### Bug Fix 2: Handling for maintenance over the limit in duration

As above previously if CCXT couldn't find OHLCV data (I.E. there had been maintenance on the Exchange) the behaviour was to always get limit amount. Even if the date time in the OHLCV data had gaps the returned Array size would always be the limit.

After the library update CCXT provides OHLCV from the since date for interval type and limit. Therefore if it encounters a maintenance period it returns, less than an Array size of the limit. The issue then occurs if the maintenance duration was over the limit in duration. This causes Superalgos to get stuck in a loop (the since date can't increase and the getOHLCV function restarts pulling the same zero Array(0)). An example of maintenance over 1,000 minutes in duration is Binance on 2018-02-08.

Therefore the new function findNextValidOHLCV will skip to the next valid OHLCV and restart the getOHLCV loop thereby skipping the empty maintenance period and continuing from the next valid data.

### Bug Fix 3: Unnecessary halts in pulling OHLCV data

As above CCXT used to always pull the limit amount of data, even if this contained gaps. Since the library update CCXT will encounter periods where it is pulling less than the limit.

The code was set to break if it detected an array size of less than the limit. The code now doesn't break the getOHLCV function unless the data is up to date (I.E. it is pulling less OHLCV's as it is only pulling data from the current date (I.E. the last minute of data)).


This is a big one as it affects the pulling of data so probably needs some review.