### PR TITLE
Docker tagging & cleanup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     - id: repository
       uses: ASzc/change-string-case-action@v1
       with:
-        string: "${{ github.repository }}/${{ github.event.repository.name }}" 
+        string: "${{ github.repository }}"
     - uses: actions/checkout@v2
     - name: Preparation
       id: prep

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
         REGISTRY="ghcr.io"
         IMAGE="${REGISTRY}/${{ steps.repository.outputs.lowercase }}"
         TAGS="${IMAGE}:${{ github.sha }}"
-        if [[ $GITHUB_REF == ref/head/master ]]; then
+        if [[ $GITHUB_REF == refs/heads/master ]]; then
           TAGS="${TAGS},${IMAGE}:latest"
         fi
         echo ::set-output name=tags::${TAGS}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,9 @@ jobs:
         if [[ $GITHUB_REF == refs/heads/master ]]; then
           TAGS="${TAGS},${IMAGE}:latest"
         fi
+        if [[ $GITHUB_REF == refs/heads/develop ]]; then
+          TAGS="${TAGS},${IMAGE}:develop"
+        fi
         echo ::set-output name=tags::${TAGS}
     - name: Login in to registry
       uses: docker/login-action@v1

--- a/README.md
+++ b/README.md
@@ -224,16 +224,21 @@ If you wish to run Superalgos over docker platform, follow these steps.
 
 Follow the link to [install docker](https://docs.docker.com/engine/install/).
 
-## 2. Login and Run
+## 2. Run
 
 ```
-docker login ghcr.io --username your-github-username --password-stdin
-```
-```
-docker run -p 18041:18041 -p 34248 superalgos/superalgos
+docker run \
+  -d \
+  --rm \
+  --name superalgos \
+  -p 18041:18041 \
+  -p 34248:34248 \
+  ghcr.io/superalgos/superalgos:latest
 ```
 
-Now you can access to the Superalgos UI.
+Now you can access to the Superalgos UI at http://127.0.0.1:34248
+
+When you're done just exec `docker kill superalgos`
 
 **Note:** This has not been extensively tested yet. If you run into troubles, please contact us at the [Superalgos Support Group](https://t.me/superalgossupport).
 


### PR DESCRIPTION
Issues addressed:
- Fix docker tagging: `latest` tag was not being added in GitHub Actions
- Add tagging for develop branch
- Remove duplicated namespace: container was being pushed to `ghcr.io/superalgos/superalgos/superalgos` instead of `ghcr.io/superalgos/superalgos`
- Update docker run instructions: Docker login is not necessary to pull the image