### PR TITLE
Dependency: Change TaskServer WS from 7.4.0 to 7.4.6

### DIFF
--- a/Projects/Foundations/TS/Task-Modules/package-lock.json
+++ b/Projects/Foundations/TS/Task-Modules/package-lock.json
@@ -1,6 +1,8 @@
 {
-  "requires": true,
+  "name": "task-modules",
+  "version": "0.0.6",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "ip": {
       "version": "1.1.5",
@@ -8,9 +10,9 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ws": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
     }
   }
 }

--- a/Projects/Foundations/TS/Task-Modules/package.json
+++ b/Projects/Foundations/TS/Task-Modules/package.json
@@ -1,13 +1,13 @@
 {
-    "name": "task-modules",
-    "version": "0.0.6",
-    "description": "Tasks Server",
-    "main": "EventServerClient.js",
-    "author": {
-      "name": "Luis-Fernando-Molina"
-    },
-    "dependencies": {
-      "ip": "^1.1.5",
-      "ws": "^7.4.0"
-    }
+  "name": "task-modules",
+  "version": "0.0.6",
+  "description": "Tasks Server",
+  "main": "EventServerClient.js",
+  "author": {
+    "name": "Luis-Fernando-Molina"
+  },
+  "dependencies": {
+    "ip": "^1.1.5",
+    "ws": "^7.4.6"
   }
+}


### PR DESCRIPTION
I've been running this for over a week on Windows 10 and Ubuntu with no seen issues.
Reading the release notes there are no changes which should interfere with Superalgos.