### PR TITLE
Sync trade calculations if the data is present

### DIFF
--- a/Projects/Foundations/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/APIs/ExchangeAPI.js
+++ b/Projects/Foundations/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/APIs/ExchangeAPI.js
@@ -98,6 +98,13 @@
             tradingSystem.addError([tradingSystemOrder.id, message, docs])
 
             logError("getOrder -> Error = " + err.message);
+            if ( /[0-9a-z]+ NotFound/.test(err.message) ) {
+                logInfo("getOrder -> NotFound, so order is actually closed.")
+                order = {
+                    status: 'NotFound'
+                }
+                return order
+            }
         }
     }
 

--- a/Projects/Foundations/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/OrdersCalculations.js
+++ b/Projects/Foundations/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/OrdersCalculations.js
@@ -55,8 +55,10 @@ exports.newFoundationsBotModulesOrdersCalculations = function (processIndex) {
         /* This calculation needs to happen only once, the first time the order is checked. */
         if (tradingEngineOrder.orderBaseAsset.actualSize.value !== tradingEngineOrder.orderBaseAsset.actualSize.config.initialValue) { return }
 
-        /* We receive the actual size from the exchange at the order.amount field. */
-        tradingEngineOrder.orderBaseAsset.actualSize.value = order.amount
+        if ( order.amount !== undefined) {
+            /* We receive the actual size from the exchange at the order.amount field. */
+            tradingEngineOrder.orderBaseAsset.actualSize.value = order.amount
+        }
 
         recalculateActualSize()
         recalculateSizePlaced()
@@ -122,7 +124,7 @@ exports.newFoundationsBotModulesOrdersCalculations = function (processIndex) {
             available, but it seems sometimes it is not. In those cases we use the price.
             */
             tradingEngineOrder.orderStatistics.actualRate.value = order.average
-        } else {
+        } else if (order.price !== undefined) {
             /*
             We use the order.price when the average is not available.
             */
@@ -260,8 +262,10 @@ exports.newFoundationsBotModulesOrdersCalculations = function (processIndex) {
         We know this field will go up until reaching the Actual Size. Once it reaches that number
         the order will be 100% filled. 
         */
-        tradingEngineOrder.orderStatistics.percentageFilled.value = order.filled * 100 / tradingEngineOrder.orderBaseAsset.actualSize.value
-        tradingEngineOrder.orderStatistics.percentageFilled.value = TS.projects.foundations.utilities.miscellaneousFunctions.truncateToThisPrecision(tradingEngineOrder.orderStatistics.percentageFilled.value, 10)
+        if (order.filled !== undefined) {
+            tradingEngineOrder.orderStatistics.percentageFilled.value = order.filled * 100 / tradingEngineOrder.orderBaseAsset.actualSize.value
+            tradingEngineOrder.orderStatistics.percentageFilled.value = TS.projects.foundations.utilities.miscellaneousFunctions.truncateToThisPrecision(tradingEngineOrder.orderStatistics.percentageFilled.value, 10)
+        }
     }
 
     async function feesPaidCalculation(tradingEngineStage, tradingSystemOrder, tradingEngineOrder, order, applyFeePercentage) {
@@ -303,8 +307,10 @@ exports.newFoundationsBotModulesOrdersCalculations = function (processIndex) {
         take it from there for our Order Base Asset. The amount in order.filled does
         not reflect the Fees Paid, even if we are paying the fees in Base Asset. 
         */
-        tradingEngineOrder.orderBaseAsset.sizeFilled.value = order.filled
-        tradingEngineOrder.orderBaseAsset.sizeFilled.value = TS.projects.foundations.utilities.miscellaneousFunctions.truncateToThisPrecision(tradingEngineOrder.orderBaseAsset.sizeFilled.value, 10)
+        if (order.filled !== undefined) {
+            tradingEngineOrder.orderBaseAsset.sizeFilled.value = order.filled
+            tradingEngineOrder.orderBaseAsset.sizeFilled.value = TS.projects.foundations.utilities.miscellaneousFunctions.truncateToThisPrecision(tradingEngineOrder.orderBaseAsset.sizeFilled.value, 10)
+        }
         /*
         For Quoted Asset, CCXT does not return any field with the size filled, so we 
         need to calculate that by ourselves. 

--- a/Projects/Foundations/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/TradingOrders.js
+++ b/Projects/Foundations/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/TradingOrders.js
@@ -664,59 +664,6 @@ exports.newFoundationsBotModulesTradingOrders = function (processIndex) {
             return false
         }
 
-        if (order === null) {
-            /* 
-            Some exchanges, like Coinbase Pro, deletes orders after being cancelled, and when we request information
-            about them, it returns null. We will interprate this as ORDER NOT FOUND.
-            */
-            message = 'Order Not Found at the Exchange'
-            docs = {
-                project: 'Foundations',
-                category: 'Topic',
-                type: 'TS LF Trading Bot Warning - ' + message,
-                placeholder: {}
-            }
-
-            tradingSystem.addWarning(
-                [
-                    [tradingSystemOrder.id, tradingEngineOrder.id],
-                    message,
-                    docs
-                ]
-            )
-
-            /* Close this Order */
-            tradingEngineOrder.status.value = 'Closed'
-            /* 
-            We must be carefull here not to overide an already defined exitType. It can happen
-            for instance that the order was cancellerd from the but veryfing the cancellation
-            was not possible because of a connection to the exchange problem. In that case
-            the exit type was defined but the order was kept open until the verification could be done.
-            */
-            if (tradingEngineOrder.exitType.value === tradingEngineOrder.exitType.config.initialValue) {
-                tradingEngineOrder.exitType.value = 'Not Found at the Exchange'
-            }
-            /* Initialize this */
-            tradingEngine.tradingCurrent.tradingEpisode.distanceToTradingEvent.closeOrder.value = 1
-
-            await updateEndsWithCycle(tradingEngineOrder)
-
-            let message = "Order Closed"
-            let docs = {
-                project: 'Foundations',
-                category: 'Topic',
-                type: 'TS LF Trading Bot Info - ' + message,
-                placeholder: {}
-            }
-            contextInfo = {
-                exitType: tradingEngineOrder.exitType.value
-            }
-            TS.projects.education.utilities.docsFunctions.buildPlaceholder(docs, undefined, undefined, undefined, undefined, undefined, contextInfo)
-
-            tradingSystem.addInfo([tradingSystemOrder.id, message, docs])
-            return true
-        }
-
         const AT_EXCHANGE_STATUS = {
             OPEN: 'open',
             CLOSED: 'closed',
@@ -1167,6 +1114,36 @@ exports.newFoundationsBotModulesTradingOrders = function (processIndex) {
                     ]
                 )
                 return false
+            }
+            if (order.status === 'NotFound') {
+                /*
+                Some exchanges, like Coinbase Pro, deletes orders after being cancelled, and when we request information
+                about them, it returns null. We will interprate this as ORDER NOT FOUND.
+                */
+                const message = 'Order Not Found at the Exchange'
+                let docs = {
+                    project: 'Superalgos',
+                    category: 'Topic',
+                    type: 'TS LF Trading Bot Warning - ' + message,
+                    placeholder: {}
+                }
+
+                tradingSystem.addWarning(
+                    [
+                        [tradingSystemOrder.id, tradingEngineOrder.id],
+                        message,
+                        docs
+                    ]
+                )
+                /*
+                We must be carefull here not to overide an already defined exitType. It can happen
+                for instance that the order was cancellerd from the but veryfing the cancellation
+                was not possible because of a connection to the exchange problem. In that case
+                the exit type was defined but the order was kept open until the verification could be done.
+                */
+                if (tradingEngineOrder.exitType.value === tradingEngineOrder.exitType.config.initialValue) {
+                    tradingEngineOrder.exitType.value = 'Not Found at the Exchange'
+                }
             }
 
             /* 


### PR DESCRIPTION
Coinbase Pro removes the order from its records after it is closed so there is no way for Superalgos to get information about it, which returns an empty `order` object. From there we must assume none of the values within Superalgos have changed so no new order synchronization is necessary.