### PR TITLE
Update READMEs, add brewfile, add npm script aliases

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,3 @@
+brew "git"
+brew "node"
+brew "npm"

--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,4 @@
 brew "git"
 brew "node"
 brew "npm"
+brew "python@3.9"

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,0 +1,273 @@
+# Superalgos Docker Guide
+
+## Table of Contents
+
+- [Introduction](#introduction)
+- [Installation](#installation)
+  - [Mac OS](#mac-os)
+  - [Windows](#windows)
+  - [Linux and BSD](#linux-and-bsd)
+- [Running Superalgos](#running-superalgos)
+  - [Using Docker-Compose](#using-docker-compose)
+- [Docker Best Practices](#docker-best-practices)
+- [Docker Development Best Practices](#docker-development-best-practices)
+  - [Dockerfile Best Practices](#dockerfile-best-practices)
+  - [Twelve Factor App](#twelve-factor-app)
+
+## Introduction
+
+This walkthrough is broken up into to parts: a quick-start guide to running [Superalgos](https://github.com/Superalgos/Superalgos) with Docker and a deeper, more theoretical dive into containers with the hopes of explaining some of the design decisions.
+
+[Superalgos](https://github.com/Superalgos/Superalgos), at its core, is a web application which also means it can be deployed inside a container like many other web applications. One of the leading platforms for operating containers is Docker. Docker can run on many different operatng systems and compute platforms. The containers provide an easy, fast, repeatable, and secure way to deploy and distribute applications. While it doesn't take much experience to run containers or Docker, there are some basics that any user should learn in order to use the technology effectively.
+
+Before getting started, be aware that Docker is not the originally intended method of running the [Superalgos](https://github.com/Superalgos/Superalgos) application and as such there are some drawbacks to doing so. Namely, you won't be able contribute back to the project or configure your Governance profile. We'll discuss this more later. Therefore, you should only consider using the Docker container for production deployments.
+
+It is also worth noting that [Superalgos](https://github.com/Superalgos/Superalgos) is very resource intense so it is best to get acquainted with the software by running it on a fast computer with a good amount of RAM as opposed to a tiny, slow Raspberry Pi. But, once you are ready to run a production deployment, then a more economical server is preferred.
+
+Docker container images are hosted on `ghcr`. You can browse the containers in the [Packages section of the code repository](https://github.com/users/Superalgos/packages/container/package/superalgos).
+
+> **Note:** The container and the application are still under heavy development and testing. Please join the [Superalgos SysAdmins Group](https://t.me/superalgossysadmins) to discuss any issues you may run into.
+
+## Installation
+
+First, Docker Desktop needs to be installed on a Mac or Windows computer in order to run the containers. Linux and BSD users will need Docker Engine. Docker-compose is also recommended and it should be included with Docker Desktop, but it may need to be installed separately.
+
+### Mac OS
+
+Docker can be downloaded from the Docker Store following the [directions in the official Docker Docs](https://docs.docker.com/desktop/mac/install/). It can also be installed from the command line using Homebrew.
+
+```shell
+brew cask install docker
+brew install docker-compose
+```
+
+Then, make sure Docker Desktop is running. An easy way to check is to push `Cmd + space` then type `docker.app` in the search bar. You should also see the little whale icon in the top menu bar near the clock.
+
+### Windows
+
+Windows requires a few more steps than Mac OS, but it can also be downloaded from the Docker Store following the [directions in the official Docker Docs](https://docs.docker.com/desktop/windows/install/). It can also be installed from the command line using Chocolatey.
+
+```shell
+choco install docker-desktop
+```
+
+Docker should automatically start after installation. If you don't see the whale icon in the tray by the clock, then find `Docker` in the start menu.
+
+### Linux and BSD
+
+On Linux and BSD systems, Docker can be installed using the prefered package manager. [Step by step instructions for many different distributions](https://docs.docker.com/engine/install/debian/) of Linux can be found in the official Docker Docs. Since [Superalgos](https://github.com/Superalgos/Superalgos) runs well on Raspberry Pi 4 single-board computers, I'm going to illustrate the commands necessary to run [Superalgos](https://github.com/Superalgos/Superalgos) on the Raspbian Linux distribution.
+
+```shell
+# install the requirements
+sudo apt-get update
+sudo apt-get install \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+
+# add the gpg keys to verify the packages
+curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+
+# confgure the official repository
+echo \
+  "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# install docker engine
+sudo apt-get update
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose
+```
+
+Docker should automatically start when it is done installing. You can check its status with `systemctl status docker`. To make things easier, ensure your user is added to the `docker` group. Type `id` at the command prompt and you should see something like `groups=...999(docker)`. If you don't see it listed, you can add yourself with `sudo usermod -a -G docker <username>`.
+
+## Running Superalgos
+
+Now that we have Docker installed and running, we can run the container. The option `--rm` will remove the isntance of the container when it is exited.
+
+```shell
+docker run --rm ghcr.io/superalgos/superalgos:latest
+```
+
+You'll see some messages showing the container being downloaded and then some messages from the application itself showing that it is starting up and ready to accept connections. We'll stop the container now and add in a few more options so make it more useful, so press `ctrl + c` to exit.
+
+We'll need to expose some ports so we can actually connect to it from our browser. Also, we'll want to create a few directories on our host file system so we can save, or persist, data between container reboots.
+
+- `-d` to run the container daemonized, in the background
+- `-p` to map ports to the host system to allow connections
+- `-v` to mount local directories inside the container to persist data
+- `--name` to assign a name to the container for easier reference
+
+```shell
+# create the data directories
+mkdir -p Data-Storage Log-Files My-Workspaces
+
+# run the container with the extra options
+docker run \
+  -d \
+  --rm \
+  --name superalgos \
+  --user $(id -u):$(id -g) \
+  -p 18041:18041 \
+  -p 34248:34248 \
+  -v $(pwd)/Data-Storage:/app/Data-Storage \
+  -v $(pwd)/Log-Files:/app/Log-Files \
+  -v $(pwd)/My-Workspaces:/app/My-Workspaces \
+  ghcr.io/superalgos/superalgos:latest
+```
+
+You can check the status of the container with `docker ps -a` and view the logs with `docker logs superalgos`.
+
+Note that you will see one error in the log output informing you that `git` is not installed. This is intentional and is not required for the bot to function properly.
+
+Now you can open your browser and load the application front end. Try loading `http://localhost:34248` if you are on the same computer that is running the container, otherwise use the host ip, for example `http://192.168.1.10:34248`.
+
+If you want to stop the container, you can run `docker stop superalgos`. When you want to upgrade the container, use:
+
+```shell
+docker pull ghcr.io/superalgos/superalgos:latest
+docker stop superalgos
+docker run \
+  -d \
+  --rm \
+  --name superalgos \
+  --user $(id -u):$(id -g) \
+  -p 18041:18041 \
+  -p 34248:34248 \
+  -v $(pwd)/Data-Storage:/app/Data-Storage \
+  -v $(pwd)/Log-Files:/app/Log-Files \
+  -v $(pwd)/My-Workspaces:/app/My-Workspaces \
+  ghcr.io/superalgos/superalgos:latest
+```
+
+Let's stop the container for now (`docker stop superalgos`) and we'll run it again using `docker-compose`.
+
+Continue reading the [Docker Command Line documentation](https://docs.docker.com/engine/reference/commandline/cli/) for more details.
+
+### Using Docker-Compose
+
+Docker-compose is a wrapper for the Docker API which makes it a little easier to maintain a declaritive configuration for an application instead of using the direct command line commands. There is a sample docker-compose configuration included in the [Superalgos](https://github.com/Superalgos/Superalgos) which you can as the basis for your own configuration.
+
+Let's download the sample and edit it. If you don't use `vim`, change that command for your preferred editor.
+
+```shell
+wget https://raw.githubusercontent.com/Superalgos/Superalgos/master/Docker/docker-compose.yml
+vim docker-compose.yml
+```
+
+Now, let's change some of the settings:
+
+```yaml
+version: "3"
+services:
+  superalgos:
+    image: ghcr.io/superalgos/superalgos:latest
+    command: ["minMemo"]
+    user: "$UID:$GID"
+    ports:
+      - '34248:34248'
+      - '18041:18041'
+    volumes:
+      - ./Data-Storage:/app/Data-Storage
+      - ./Log-Files:/app/Log-Files
+      - ./My-Workspaces:/app/My-Workspaces
+    restart: on-failure
+```
+
+You can see we have the same ports and volumes mapped. We also get a few extra settings like `command`, `environment`, and `restart`.
+
+- `command` adds an extra setting to the main startup, so the application ends up running with the full command `node platform noBrowser minMemo`. The base of that command is defined as the `ENTRYPOINT` in the `Dockerfile` that builds the container.
+- `user` defines the UID and GID the container should run as so that the data can be persisted with the correct permissions in the Data-Storage, Log-Files, and My-Workspaces directories that we created on the host. If you leave this out, the container will use the built in `superalgos` user which has `uid: 1001` and `gid: 1001`.  Instead of using variables, you could also hard-code these UID and GID numbers into the configuration.
+- `restart` tells Docker to restart the container if an error occurs.
+
+Save the file and exit the editor. If you are using `vim`, hit escape and then type `:wq!` or press `shift + Z + Z` (two capital Z's).
+
+Now, start the container with `docker-compose up`. This will start the container in the foreground and you'll connect to the log output. Hit `ctrl + c` to exit. Going forward, you'll want to add the `-d` option to start the container and keep it running in the background.
+
+```shell
+# some preliminary configuration to set up the persistent data directories
+mkdir -p Data-Storage Log-Files My-Workspaces
+export UID=$(id -u)
+export GID=$(id -g)
+
+# run the container in the background
+docker-compose up -d
+```
+
+Now you have several `docker-compose` commands at your disposal to interact with the container:
+
+- `docker-compose ps` to see details of the container
+- `docker-compose logs` to see the logs
+- `docker-compose down` to stop and remove the instance of the container
+- `docker-compose pull` to pull the container, or a new version of the `latest` tag
+
+Putting some of those concepts together, you can keep the running container up to date with this one-liner:
+
+```shell
+docker-compose pull && docker-compose down && docker-compose up -d
+```
+
+Explore the full [Docker Compose documentation](https://docs.docker.com/compose/) for more information.
+
+## Docker Best Practices
+
+As with any technology, there are lots of ways of doing things. A lot of them will give the same end result, but some may have fewer steps, or be more secure, or be more maintainable. That is where "best practices" come in. They aren't there to necessarily tell you what to do and what not to do, but they are there to help guide you in the right direction. A lot of times, they help you avoid making architectural mistakes that could come back and bite you further down the road.
+
+One general best practice when running a production deployment is to avoid breaking changes by pinning to specific container tags. The `shasum hash` and the `release` tags are the best to use. These will generally ensure you are always running the same code and it will only upgrade when configured to do so.  The other tags will change which code they are pointing to more frequently and without notice.
+
+- `latest` : the absolute latest build
+- `master` : the latest master branch build
+- `develop` : the latest develop branch build
+- `<shasum hash>` : a specific git commit hash
+- `<release>` : corresponds with a Github Release (git tag), i.e. `beta-10`
+
+## Docker Development Best Practices
+
+Docker has many advantages which can aid in every step from development through production deployment. There are some useful tips located directly in the [Docker documentation](https://docs.docker.com/develop/dev-best-practices/). Concisely, they are to keep the build images small, a few tips on when and how to persist data, and to use CI/CD for testing and deployment. All of these tips are used in one way or another as a part of the [Superalgos](https://github.com/Superalgos/Superalgos) project.
+
+- Use a minimal base image and multi-stage build. Superalgos is currently using an [alpine](https://www.alpinelinux.org/) base image but [distroless](https://github.com/GoogleContainerTools/distroless) is becoming more common and some times using a base image like [python-slim](https://hub.docker.com/_/python) is the bast that can be achieved.
+- The images are quite large (around 2 GB in size), unfortunately, because the codebase itself is large. We've recently put in a lot of effort to make these images as small as possible.
+- The images are built automatically using Github Actions when pull requests are merged.
+- With the correct configuration, data, like data mine and trading bot information, is persisted to the host using volume mounts
+
+### Dockerfile Best Practices
+
+Docker maintains a list of [Dockerfile best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) in their main documentation. These tips dictate many of the decisions around the Superalgos Dockerfile. Some of the tips that are used by [Superalgos](https://github.com/Superalgos/Superalgos) are listed below.
+
+- Use `.dockerignore` to prevent unwanted data from entering the container. This keeps the container small but also enhances security to prevent secrets from leaking into a container by accident.
+- Don't install unneccesary packages. In lieu of multi-stage builds, build caches and build dependencies are removed before finalizing the container. Only packages that are necessary for the execution of the application are installed. This is why `git` is not present.
+- Minimize the number of layers. Many `RUN` commands are combined into one using `&&` in order to reduce the number of layers.
+- Sort multiline arguments. This mostly enhances readability and maintainability.
+- Leverage build cache. When testing locally, several of the tips above help levarage the build cache and speed up build times.
+
+### Twelve Factor App
+
+[Superalgos](https://github.com/Superalgos/Superalgos) is a web app but it was originally designed to be run on a local workstation or server on a trusted network. However, I don't think it would be prudent to talk about Docker best practices without mentioning the [Twelve Factor App](https://12factor.net/) manifesto. Over time, [Superalgos](https://github.com/Superalgos/Superalgos) itself may iterate and implement more and more of these principles as more people get involved and more people deploy production environments.
+
+The Twelve Factors:
+
+- Codebase: One codebase tracked in revision control, many deploys
+  - Superalgos utilizes one GitHub repository
+- Dependencies: Explicitly declare and isolate dependencies
+  - Superalgos is a node.js app and uses npm to track and install dependencies
+- Config: Store config in the environment
+  - Superalgos does not use environment variables the moment for configuration. Options are passed on the command line at run time. Other configuration is hard coded into the Workspaces.
+- Backing services: Treat backing services as attached resources
+  - Superalgos connects to external services via API calls over HTTP (TCP)
+- Build, release, run: Strictly separate build and run stages
+  - Superalgos is deployed by end users in their own local environments
+- Processes: Execute the app as one or more stateless processes
+  - Superalgos is one application
+- Port binding: Export services via port binding
+  - Superalgos exposes an HTTP frontend port and a Websockets backend port (TCP)
+- Concurrency: Scale out via the process model
+  - Superalgos can be clustered but the front end and backend do not necessarily scale out independently from each other
+- Disposability: Maximize robustness with fast startup and graceful shutdown
+  - Superalgos is not stateless in that the data files must be persisted to disk. Also, Superalgos cannot run behind a load balancer and have requests randomly distributed to different backend servers.
+- Dev/prod parity: Keep development, staging, and production as similar as possible
+  - Superalgos doesn't have its own production environment but the container makes it easy to ensure development environments are the same as what a user will see when they deploy it for themselves in their own production environment.
+- Logs: Treat logs as event streams
+  - Superalgos sends its own application logs to standard out. The trading mine logs are sent to flat files (persisted through volume mounts)
+- Admin processes: Run admin/management tasks as one-off processes
+  - Superalgos does not have any admin or management tasks outside of what is used to create the container at build time.

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: ./Docker/Dockerfile
     image: ghcr.io/superalgos/superalgos:latest
     command: ["minMemo"]
+    user: "$UID:$GID"
     ports:
       - '34248:34248'
       - '18041:18041'
@@ -13,7 +14,4 @@ services:
       - ../Data-Storage:/app/Data-Storage
       - ../Log-Files:/app/Log-Files
       - ../My-Workspaces:/app/My-Workspaces
-    environment:
-      PUID: '1000'
-      PGID: '1000'
     restart: on-failure

--- a/README.md
+++ b/README.md
@@ -5,7 +5,52 @@
 ![last-commit](https://img.shields.io/github/last-commit/Superalgos/Superalgos/develop?label=last%20commit%20to%20develop)
 ![bot-friendliness](https://img.shields.io/badge/Bot%20Friendliness%20Level-119%25-yellow)
 
-Superalgos is not just another open-source project. We are an open and welcoming community devised, nurtured, and incentivized with the project's native <a href="https://superalgos.org/token-overview.shtml" target="_blank">Superalgos (SA) Token</a> to build an <a href="https://superalgos.org/" target="_blank">open trading intelligence network</a>.
+## Table of Contents
+
+- [Table of Contents](#table-of-contents)
+- [Introduction](#introduction)
+- [Getting Started Guide](#getting-started-guide)
+- [Pre-Requisites](#pre-requisites)
+  - [Windows Install](#windows-install)
+  - [Mac OS Install](#mac-os-install)
+  - [Linux Install (e.g. Raspberry Pi running Raspberry Pi OS/Raspbian)](#linux-install--eg-raspberry-pi-running-raspberry-pi-os-raspbian-)
+- [Superalgos Platform Client Installation](#superalgos-platform-client-installation)
+  - [Fork the Superalgos Repository](#fork-the-superalgos-repository)
+  - [Clone Your Fork](#clone-your-fork)
+  - [Install Node Dependencies](#install-node-dependencies)
+    - [Troubleshooting Dependency Installation](#troubleshooting-dependency-installation)
+    - [Enable Desktop Shortcut in Ubuntu](#enable-desktop-shortcut-in-ubuntu)
+  - [Installation Notes](#installation-notes)
+  - [Uninstall](#uninstall)
+- [Usage](#usage)
+  - [Run the Client and GUI](#run-the-client-and-gui)
+    - [Using the shortcuts](#using-the-shortcuts)
+    - [Using the Command Line](#using-the-command-line)
+  - [Usage Notes](#usage-notes)
+  - [Running Superalgos on a Headless Linux Server as a Daemon](#running-superalgos-on-a-headless-linux-server-as-a-daemon)
+    - [Using Systemd](#using-systemd)
+  - [Docker Deployments](#docker-deployments)
+- [Welcome Tutorial](#welcome-tutorial)
+- [What is the Superalgos Platform?](#what-is-the-superalgos-platform-)
+  - [Superalgos Platform Features](#superalgos-platform-features)
+  - [Superalgos Development Pipeline](#superalgos-development-pipeline)
+  - [Superalgos is User-centric](#superalgos-is-user-centric)
+  - [Superalgos Platform Allows You To](#superalgos-platform-allows-you-to)
+  - [Superalgos Platform for Developers](#superalgos-platform-for-developers)
+  - [Superalgos Platform Saves You Time](#superalgos-platform-saves-you-time)
+  - [Superalgos Platform is Permissionless](#superalgos-platform-is-permissionless)
+  - [Superalgos Platform for Algo-Trders](#superalgos-platform-for-algo-trders)
+  - [Superalgos Platform Saves You Money](#superalgos-platform-saves-you-money)
+  - [Superalgos Platform Minimizes Risks](#superalgos-platform-minimizes-risks)
+  - [Superalgos Platform for Companies](#superalgos-platform-for-companies)
+- [Support](#support)
+- [Other Resources](#other-resources)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Introduction
+
+Superalgos is not just another open-source project. We are an open and welcoming community devised, nurtured, and incentivized with the project's native [Superalgos (SA) Token](https://superalgos.org/token-overview.shtml) to build an [open trading intelligence network](https://superalgos.org/).
 
 You will notice the difference as soon as you join the [Telegram Community Group](https://t.me/superalgoscommunity) or the new [Discord Server](https://discord.gg/CGeKC6WQQb)!
 
@@ -13,211 +58,203 @@ You will notice the difference as soon as you join the [Telegram Community Group
 
 ![superalgos-readme](https://user-images.githubusercontent.com/13994516/106380124-844d8980-63b0-11eb-9bd9-4f977b6c183b.gif)
 
-# Getting Started Guide
+## Getting Started Guide
 
 All procedures are the same for Windows, Linux, or Mac OS. Raspberry Pi terminal commands have been included for ease of use.
 
-> **IMPORTANT:** Remote installations and minimalist hardware — both virtual and physical — are better suited for production deployments, where the use of the GUI is minimal. We highly recommend learning Superalgos in a local installation. Mastering the system takes time, and the use of the GUI to go through in-app tutorials is crucial during the learning process. Your experience will be orders of magnitude better if you follow this advice: leave remote installations and minimalist hardware for when you are ready to start trading live.
+> **IMPORTANT:**
+> 
+> Remote installations and minimalist hardware — both virtual and physical — are better suited for production deployments, where the use of the GUI is minimal. We highly recommend learning Superalgos in a local installation. Mastering the system takes time, and the use of the GUI to go through in-app tutorials is crucial during the learning process. Your experience will be orders of magnitude better if you follow this advice: leave remote installations and minimalist hardware for when you are ready to start trading live.
 
-# Pre-Requisites
+## Pre-Requisites
 
-## 1. Node JS Installation
+In order to run Superalgos on your computer, you will need the latest versions of Node JS and Git installed. You will also need a web browser to access the interface. Google Chrome is recommended as it is what the development team uses and supports.
 
-If you don't have it yet, download and install Node.js.
+- [Node.js download page](https://nodejs.org/en/download/)
+- [Git download page](https://git-scm.com/downloads)
+- [Google Chrome download page](https://www.google.com/chrome/)
 
-Node JS is an open-source server environment required to run Superalgos.
+### Windows Install
 
-**A.** Go to the Node JS [download page](https://nodejs.org/en/download/).
+Follow the install wizards to install the latest NodeJS and Github Desktop applications.
 
-**B.** Download your system's installer. Select *LTS Recommended for Most Users* and click the big Windows or macOS Installer button. If you are on Linux, the installer is listed further down the page.
+- [Node.js download page](https://nodejs.org/en/download/). Select "Current" then "Windows Installer", then follow the wizard to install after the download completes.
+- [GitHub Desktop downloat page](https://desktop.github.com/). Click the "Download for Windows" button and follow the wizard to install after the download completes.
+- [Google Chrome download page](https://www.google.com/chrome/). After the install, it is recommended to set Chrome as the default browser.
+- If you intend on running the machine learning features (TensorFlow), you must [install Python 2](https://www.python.org/downloads/release/python-2718/) as well.
 
-**C.** Run the installer with the default configuration — just click Next until Node.JS is fully installed. That's it! You can continue with step 2 (Git Installation).
+### Mac OS Install
 
-<hr>
+[Homebrew](https://brew.sh/) can be used to install the requirements with minimal effort on Mac OS.  After you clone the repository, change directory to the Superalgos base and install the requirements using the Brewfile. Python 3 is only required for running machine learning (TensorFlow).
 
-**NODE JS INSTALLATION FOR RASPBERRY PI USERS**
-
-You may install Node.JS just like you would on any other machine as per the above instructions. As an alternative, you may also try the following from the SSH Terminal.
-
-**NOTE:** It is best to use the most current and updated version of the FULL PiOS image.
-
+```sh
+brew install git node npm python@3.9
 ```
+
+Or use the `Brewfile` included in the code repository. After downloading, run this command in the same directory where the `Brewfile` resides:
+
+```sh
+brew bundle
+```
+
+You can use Safari or Google Chrome as your default browser. If you run into a bug in Safari, you will be asked to reproduce it in Chrome as the development team uses Chrome.
+
+### Linux Install (e.g. Raspberry Pi running Raspberry Pi OS/Raspbian)
+
+[Follow the Node.js package manager install instructions](https://nodejs.org/en/download/package-manager/) for your distribution to ensure you are getting the latest version of Node.js. Many distributions only maintain an older version in their default repositories. Python 3 is only required for running machine learning (TensorFlow).
+
+```sh
 curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+sudo apt-get install -y nodejs npm git python3
 ```
-Followed by:
-```
-sudo apt-get install -y nodejs
-```
-It is also required to install the Node Package Manager for dependancy management.
-```
-sudo apt install npm
-```
-You may also type the following to verify Node.js and NPM installation and version.
-```
+
+You may verify the installed versions with these commands:
+
+```sh
 node -v
-```
-```
-npm -v 
-```
-
-<hr>
-
-## 2. Git Installation
-
-Download and install Git.
-
-Git is an open-source distributed version control system required to download and stay up to date with Superalgos.
-
-**A.** Go to the Git [download page](https://git-scm.com/downloads).
-
-**B.** Download the version for your Operating System.
-
-**C.** Run the installer with the default configuration — just click Next until Git is fully installed.
-
-**IMPORTANT:** The latest version of Git is required to handle the authentication with GitHub.com.
-
-**NOTE FOR MAC USERS:** Depending on your setup, installing Git may be optional. The native XCode Command Line Developer Tools seems to work well. If you do install Git, we have tested Tim Harper's binary installer successfully.
-
-<hr>
-
-**GIT INSTALLATION FOR RASPBERRY PI USERS**
-
-Just like with Node.JS, you may follow the above instructions to install Git, or use the SSH Terminal command. The most recent version of PiOS has Git already installed, so this may give you an error. The error will not affect your installation.
-```
-sudo apt-get install git
+npm -v
+git --version
 ```
 
-<hr>
+If you are running headless (i.e. as a server without a monitor attached) then you do not need to install a web browser and you can follow the tutorial for information on connecting remotely to the server.
 
-## 3. Google Chrome or Safari
+## Superalgos Platform Client Installation
 
-Use Chrome, or Safari on Mac. These are the only tested browsers.
+### Fork the Superalgos Repository
 
-**A.** Go to the Chrome [download page](https://www.google.com/chrome/).
+- Scroll the page all the way to the top. Find and click the **Fork** button to create your fork/copy of this repository. To fork Superalgos you need a Github account. If you don't have one, go ahead and create it.
 
-**B.** Run the installer.
+> **NOTE**
+> 
+> A Fork is required for your contributions to the project. The reason why Superalgos is free and open-source is that the project has set up a [collective business](https://superalgos.org) in which all users may participate. The way to participate is to [contribute](https://superalgos.org/community-contribute.shtml) to make Superalgos better. The project's [token](https://superalgos.org/token-overview.shtml) is distributed among contributors.
 
-Before you begin, it is recommended that you set up Chrome/Safari as your default browser.
+### Clone Your Fork
 
-**IMPORTANT:** Use Chrome/Safari so that you have a similar environment as the dev team in case you need help. We are not testing on any other browsers, and it is a well-known fact that browsers behave differently.
+- Once the fork is created, you will land on the page of your fork. Copy the URL from your browser's address bar.
+- In your computer/laptop/server, open a command prompt or terminal. Make sure you are in a directory where you have write permissions (on most systems the terminal will open in your user's home directory, so you're good). Clone the git repository using the command:
 
-# Superalgos Platform Client Installation
-
-## 1. Fork the Superalgos Repository
-
-**A.** Scroll the page all the way to the top. Find and click the **Fork** button to create your fork/copy of this repository. To fork Superalgos you need a Github account. If you don't have one, go ahead and create it.
-
-**NOTE:** A Fork is required for your contributions to the project. The reason why Superalgos is free and open-source is that the project has set up a <a href="https://superalgos.org" target="_blank">collective business</a> in which all users may participate. The way to participate is to <a href="https://superalgos.org/community-contribute.shtml" target="_blank">contribute</a> to make Superalgos better. The project's <a href="https://superalgos.org/token-overview.shtml" target="_blank">token</a> is distributed among contributors.
-
-## 2. Clone Your Fork
-
-**A.** Once the fork is created, you will land on the page of your fork. Copy the URL from your browser's address bar.
-
-**B.** In your computer/laptop/server, open a command prompt or terminal. Make sure you are in a directory where you have write permissions (on most systems the terminal will open in your user's home directory, so you're good). Clone the git repository using the command:
-
-```
+```sh
 git clone <URL of your Superalgos fork>
 ```
 
 For example, if your Github username is John, the command will look like this:
 
-```
+```sh
 git clone https://github.com/John/Superalgos
 ```
 
 This creates the `Superalgos` folder in the current directory, which contains the whole installation.
 
-## 3. Install Node Dependencies
+### Install Node Dependencies
 
 After the Superalgos directory has been installed, the final step of installation is to set up the necessary node dependencies. In the same command prompt or terminal you just used, type the following:
 
-```
+```sh
 cd Superalgos
 ```
 
-That should take you inside the Superalgos folder created by the `git clone` command earlier. 
+That should take you inside the Superalgos folder created by the `git clone` command earlier. Now type `node setup` to install the dependencies.
 
-Now, you need to install dependencies, and there are two options:
-
-**A.** To install all basic dependencies run:
-
-```
+```sh
 node setup
 ```
 
-Then wait until you are able to type within the terminal again.
+By default, desktop shortcuts are created if they can be. Currently, Mac OS shortcuts are not created. Linux installations may require extra steps to view and use the shortcuts.
 
-This command will install and configure all additional dependencies needed by Superalgos. It will also install desktop and start menu shortcuts.
+Available Options:
 
-**B.** If you intend to use the experimental implementation of the TensorFlow Project within Superalgos, then run:
-
-```
-node setup tensorflow
+```sh
+usage: node setup <options>
 ```
 
-This command will install all dependencies plus TensorFlow dependencies.
+| Option | Description |
+| --- | --- |
+| `noShortcuts` | Do not install desktop shortcuts |
+| `tensorflow` | Include the TensorFlow dependencies |
 
-**NOTE FOR WINDOWS USERS INSTALLING TENSORFLOW DEPENDENCIES:** You may get an error at the end of the set up process. If you do, please follow the instructions following the error message.
+> **NOTE FOR WINDOWS USERS INSTALLING TENSORFLOW DEPENDENCIES:**
+> 
+> You may get an error at the end of the set up process. If you do, please follow the instructions following the error message.
 
-**NOTE FOR USERS INSTALLING MULTIPLE INSTANCES OF SUPERALGOS ON THE SAME MACHINE:** In order to avoid name conflicts between shortcuts, make sure to rename each Superalgos directory before running `node setup`.
+> **NOTE FOR USERS INSTALLING MULTIPLE INSTANCES OF SUPERALGOS ON THE SAME MACHINE:**
+> 
+> In order to avoid name conflicts between shortcuts, make sure to rename each Superalgos directory before running `node setup`.
 
-Congratulations your installation is complete!
+Congratulations your installation is complete! Follow the "Running the Application" directions below.
 
-> **The Usage section below explains how to run the app.**
-
-<hr>
-
-**DEPENDENCY INSTALLATION FOR RASPBERRY PI USERS**
-
-As noted above, running `node setup` installs GUI shortcuts by default. To suppress this behavior in headless installations, add the `noShortcuts` flag as follows:
-
-```
-node setup noShortcuts
-```
-
-or, if you wish to try the TensorFlow implementation,...
-
-```
-node setup tensorflow noShortcuts
-```
-
-<hr>
-
-**Troubleshooting Dependency Installation**
+#### Troubleshooting Dependency Installation
 
 If you are having difficulty running the node setup command here are a few common issues that may be getting in the way.
 
-**1.** Check the version of node and npm you have installed. Make sure that you are running an updated version of node greater than version 12 and npm greater than version 5. You can check which version you have by typing `node -v` and `npm -v` into a command prompt or terminal. If your version numbers are below these, you can update your installation by following the instructions outlined in the "Node JS Installation" step above.
+1. Check the version of node and npm you have installed. Make sure that you are running an updated version of node greater than version 12 and npm greater than version 5. You can check which version you have by typing `node -v` and `npm -v` into a command prompt or terminal. If your version numbers are below these, you can update your installation by following the instructions outlined in the "Node JS Installation" step above.
+2. If you are installing Superalgos in an administratively protected directory you will need to do one of the following:
+   - For Windows start your command prompt as an administrator.
+   - For Linux and Mac Systems make sure to add the sudo command to node setup.  This will look like `sudo node setup`.
+3. For Windows it is important that you have C:\Windows\System32 added to your global PATH.  For instructions on how to do this google "add to the path on Windows 10."
 
+#### Enable Desktop Shortcut in Ubuntu
 
-**2.** If you are installing Superalgos in an administratively protected directory you will need to do one of the following:
+The majority of shortcuts that are automatically installed will work out of the box. Desktop shortcuts on Ubuntu, however, require a few additional steps to set up. First, desktop icons need to be enabled within the Tweaks app.
 
-- For Windows start your command prompt as an administrator.
+- Check if Tweaks is installed.
+- If not go to Ubuntu Software.
+- Install Tweaks.
+- Open Tweaks.
+- Under extensions turn on Desktop Icons
 
-- For Linux and Mac Systems make sure to add the sudo command to node setup.  This will look like `sudo node setup`.
+![enable-ubuntu-shortcut](https://user-images.githubusercontent.com/55707292/117553927-f0780300-b019-11eb-9e36-46b509653283.gif)
 
+> **TIP:** If you do not see the desktop shortcut appear right away you may need to restart your computer.
 
-**3.** For Windows it is important that you have C:\Windows\System32 added to your global PATH.  For instructions on how to do this google "add to the path on Windows 10."
+Finally, you will need to enable the desktop shortcut. Right click Superalgos.desktop and select Allow Launching.
 
-## 4. Installation Notes
+![allow-launching](https://user-images.githubusercontent.com/55707292/117553933-fcfc5b80-b019-11eb-872c-4fad81b184d2.gif)
 
-**A.** You need to make a fork so that you may contribute work. Superalgos is a Community project and you are expected to contribute, like everyone else. You don't need to be a technical person to contribute. Fixing a typo in the docs or translating a paragraph into your native language are valuable contributions too. Superalgos has built-in features that make contributing easy. Help make Superalgos better and Superalgos will better serve you! Free-riding is not cool, particularly on free, open-source, Community-driven projects.
+Now both launcher and desktop shortcuts will launch Superalgos like any other program on your computer.
 
-**B.** The software includes an in-app self-update command / feature. It will help you stay up-to-date with the latest version of the software. Updates are on-demand, so don't worry about undesired updates. The project moves very fast and new features become available regularly, particularly if you choose to run the software in the ```develop``` branch (you may switch branches from within the app).
+### Installation Notes
 
-**C.** It is a good idea to perodically run the `node setup` command to keep the underlying dependencies for your Superalgos installation up to date.
+- You need to make a fork so that you may contribute work. Superalgos is a Community project and you are expected to contribute, like everyone else. You don't need to be a technical person to contribute. Fixing a typo in the docs or translating a paragraph into your native language are valuable contributions too. Superalgos has built-in features that make contributing easy. Help make Superalgos better and Superalgos will better serve you! Free-riding is not cool, particularly on free, open-source, Community-driven projects.
+- The software includes an in-app self-update command / feature. It will help you stay up-to-date with the latest version of the software. Updates are on-demand, so don't worry about undesired updates. The project moves very fast and new features become available regularly, particularly if you choose to run the software in the `develop` branch (you may switch branches from within the app).
+- It is a good idea to perodically run the `node setup` command to keep the underlying dependencies for your Superalgos installation up to date.
+- Before installing the client on a remote computer in an attempt to access the UI from a different machine, we highly recommend you do a standard installation on your PC / laptop first. Leave your Raspberry Pi or VPS for later, once you have done all available tutorials. This single tip will save you a lot of time: you don't need to add complexity before you learn how to handle the app, and the GUI performs best in a local installation.
 
-**D.** Before installing the client on a remote computer in an attempt to access the UI from a different machine, we highly recommend you do a standard installation on your PC / laptop first. Leave your Raspberry Pi or VPS for later, once you have done all available tutorials. This single tip will save you a lot of time: you don't need to add complexity before you learn how to handle the app, and the GUI performs best in a local installation.
+### Uninstall
 
-# Usage
+Superalgos writes nothing outside of the `Superalgos` folder other than shortcut files. In order to quickly remove the shortcut files, open a terminal or command prompt, navigate to your main Superalgos directory, and type the following command:
 
-## 1. Run the Client and GUI
+```sh
+node uninstall
+```
+
+Then simply delete the `Superalgos` folder to completely remove the application.
+
+## Usage
+
+### Run the Client and GUI
+
+#### Using the shortcuts
+
+If you ran `node setup` with no options above, then you should see a desktop icon which you can double click to launch the Superalgos application. A terminal window will show the server is running, and a browser window will open with the WebUI.
+
+#### Using the Command Line
 
 To run Superalgos, go to the Superalgos directory/folder and run this command:
 
-```
+```sh
 node platform
 ```
+
+Available Options:
+
+```sh
+usage: node platform <options>
+```
+
+| Option | Description |
+| --- | --- |
+| `minMemo` | Run with minimal memory footprint. This is critical for running on platforms with less than 8GB of ram, like a Raspberry Pi. |
+| `noBrowser` | Do not attempt to open the WebUI in a browser. This is useful on headless servers where a UI is not available. |
 
 The Client will run on your terminal and the GUI will launch on your default browser. If Chrome/Safari is not your default browser, copy the URL, close the browser, open Chrome/Safari, and paste the URL. Be patient... it takes a few seconds to fully load the GUI.
 
@@ -225,63 +262,23 @@ A Welcome Tutorial pops-up automatically. You must do this Tutorial to finish th
 
 ![run-the-system-01](https://user-images.githubusercontent.com/13994516/107037804-e5fc6200-67bb-11eb-82f2-d0f40247fa14.gif)
 
-Alternatively, you may use any of the automatically installed desktop and start menu shortcuts to launch Superalgos.
-
-**NOTE:** Shortcuts are not currently supported on Mac. Collaborators are needed to finish this feature.
-
-
-<hr>
-
-**RUNNING THE CLIENT FOR HEADLESS RASPBERRY PI USERS**
-
-If you are running a headless Raspberry Pi (one without a screen) you may need to change directories first and run Superalgos with the `minMemo` and `noBrowser` options.
-
-```
-cd Superalgos
-```
-then
-```
-node platform  minMemo noBrowser
-```
-
-<hr>
-
-**NOTE FOR UBUNTU USERS**: Enable Desktop Shortcut
-
-The majority of shortcuts that are automatically installed will work out of the box. Desktop shortcuts on Ubuntu, however, require a few additional steps to set up.
-
-First, desktop icons need to be enabled within the Tweaks app.
-* Check if Tweaks is installed.
-* If not go to Ubuntu Software.
-* Install Tweaks.
-* Open Tweaks.
-* Under extensions turn on Desktop Icons
-
-![enable-ubuntu-shortcut](https://user-images.githubusercontent.com/55707292/117553927-f0780300-b019-11eb-9e36-46b509653283.gif)
-
-**TIP:** If you do not see the desktop shortcut appear right away you may need to restart your computer.
-
-Finally, you will need to enable the desktop shortcut.
-* Right click Superalgos.desktop and select Allow Launching.
-
-![allow-launching](https://user-images.githubusercontent.com/55707292/117553933-fcfc5b80-b019-11eb-872c-4fad81b184d2.gif)
-
-Now both launcher and desktop shortcuts will launch Superalgos like any other program on your computer.
-
-## 3. Usage Notes
+### Usage Notes
 
 We are testing the UI on Google Chrome and Safari on macOS only. It may work on other browsers as well &mdash; or not. If you are running on a different browser and ever need support, make sure you mention that fact upfront, or even better, try on Chrome/Safari first.
 
- **TIP:** If your computer has 8 GB of RAM or less, use ```node platform minMemo``` to run the system with minimal RAM requirements.
+> **TIP:**
+> 
+> If your computer has 8 GB of RAM or less, use `node platform minMemo` to run the system with minimal RAM requirements.
 
-# Running Superalgos on a Headless Linux Server as a Daemon
+### Running Superalgos on a Headless Linux Server as a Daemon
 
 If you're running Superalgos on a headless linux server like a Raspberry Pi, you might want to run it as a daemon so it isn't attached to your current login session. The easiest, most standard way to go about this is probably using `systemd`. Most linux distributions use it as default init system/service manager.
 
-## Using `systemd`
+#### Using Systemd
 
 Create a `superalgos.service` file looking like this (change `<user>` to your user name and `/path/to/Superalgos` to your Superalgos folder, for instance `/home/John/Superalgos`):
-```
+
+```ini
 [Unit]
 Description=Superalgos Platform Client
 
@@ -293,296 +290,202 @@ ExecStart=/usr/bin/node platform minMemo noBrowser
 
 [Install]
 WantedBy=multi-user.target
-
-```
-There is no need to run Superalgos as root so we're running it as a user. The `minMemo` option assumes you're running on a small machine like a Raspberry Pi, while `noBrowser` makes sense for running daemonized.
-
-Now, as root (or using `sudo`), put the file `superalgos.service` you just created in `/etc/systemd/system/` and issue the command
-```
-systemctl enable superalgos
-```
-This will install the service so that Superalgos is started on boot. To start it manually, do (again as root or with `sudo`)
-```
-systemctl start superalgos
 ```
 
-To see the output of Superalgos, use
+There is no need to run Superalgos as root so we're running it as a user. The `minMemo` option assumes you're running on a small machine like a Raspberry Pi, while `noBrowser` makes sense for running daemonized. Now, you'll need to move the file to `/etc/systemd/system/` in order for it to be recognized. You'll need then to enable and start the service.
+
+```sh
+sudo mv superalgos.service /etc/systemd/system
+sudo systemctl daemon-reload
+sudo systemctl enable superalgos
+sudo systemctl start superalgos
 ```
+
+To see the output of Superalgos, use:
+
+```sh
 journalctl -u superalgos
 ```
-or to follow the output,
-```
+
+or to follow the output with `-f`:
+
+```sh
 journalctl -u superalgos -f
 ```
 
-# Uninstall
+### Docker Deployments
 
-Superalgos writes nothing outside of the ```Superalgos``` folder other than shortcut files. To uninstall the software, follow these steps:
+See the [Docker Readme for more information](Docker/README.md).
 
-Open a terminal or command prompt and navigate to your main Superalgos directory and type the following command:
-```
-node uninstall
-```
-This will remove any shortcut files that have been installed. 
-
-Then simply delete the `Superalgos` folder. There will be nothing left on your computor.
-
-# Welcome Tutorial
+## Welcome Tutorial
 
 Once the app finishes loading, an interactive tutorial takes you by the hand and walks you all around the system while you learn the basic skills required to use the interface, mine data, backtest strategies, and even run a live trading session. It is highly recommended you follow the tutorial until the end, as it is carefully crafted to make your onboarding as easy as possible. Tutorials are the absolute best way to tackle the learning curve. You should do all tutorials before you start exploring other avenues on your own.
 
 ![welcome-tutorial-00](https://user-images.githubusercontent.com/13994516/107038771-4a6bf100-67bd-11eb-92e0-353525a972a9.gif)
 
- **NOTE:** The tutorial uses Binance or Binance US as the exchange of choice. If you don't have an account with Binance or Binance US, you will still be able to follow 100% of the tutorial. When you get to the live trading section, keep going even if you don't intend to run the session. You may learn how to work with other exchanges later on.
+> **NOTE:**
+> 
+> The tutorial uses Binance or Binance US as the exchange of choice. If you don't have an account with Binance or Binance US, you will still be able to follow 100% of the tutorial. When you get to the live trading section, keep going even if you don't intend to run the session. You may learn how to work with other exchanges later on.
 
-# Docker Deployments
+## What is the Superalgos Platform?
 
-Docker container images can be found at https://github.com/users/Superalgos/packages/container/package/superalgos
-
-If you wish to run Superalgos over docker platform, follow these steps.
-
-**Note:** This has not been extensively tested yet. If you run into troubles, please contact us at the [Superalgos Support Group](https://t.me/superalgossupport).
-
-## 1. Install Docker
-
-Follow the link to [install docker](https://docs.docker.com/engine/install/).
-
-## 2. Run
-
-
-### Option A. Using pre-built container
-
-You will need to create local storage directories beforehand, by example with `mkdir Data-Storage Log-Files My-Workspaces`
-
-```
-docker run \
-  -d \
-  --rm \
-  --name superalgos \
-  -p 18041:18041 \
-  -p 34248:34248 \
-  -v $(pwd)/Data-Storage:/app/Data-Storage \
-  -v $(pwd)/Log-Files:/app/Log-Files \
-  -v $(pwd)/My-Workspaces:/app/My-Workspaces \
-  ghcr.io/superalgos/superalgos:latest
-```
-
-Now you can access the Superalgos UI at http://127.0.0.1:34248
-
-To see console logs you can use `docker logs superalgos -f`
-
-When you're done just exec `docker kill superalgos`
-
-### Option B. Build container locally using docker-compose
-
-Follow the link to [install docker-compose](https://docs.docker.com/compose/install/)
-
-Run `docker-compose -f Docker/docker-compose.yml up`.
-
-## Configure the Container Environment
-
-### Available image tags
-
-To avoid breaking changes, the `shasum hash` and the `release` tags are the best to use. These will generally ensure you are always running the same code. The other tags will change which code they are pointing to more frequently and without notice.
-
-- `latest` : the absolute latest build
-- `master` : the latest master branch build
-- `develop` : the latest develop branch build
-- `<shasum hash>` : a specific git commit hash
-- `<release>` : corresponds with a Github Release (git tag), i.e. `beta-10`
-
-### Environment variables
-
-`PUID` and `GUID` environment variables can be used to help avoid permissions issues in the mounted volumes between the container environment and the local OS environment. The default `PUID` and `GUID` is `1000`. You can view the current user's PUID and GUID with the `id` command.
-
-## Troubleshooting
-
-Some users have reported the Docker installation was not working, and the root cause was that the ad blocker was blocking the scripts to run.
-
-# Superalgos is User-centric
-
-* No ads, anywhere.
-
-* No sign-up / logins.
-
-* No user/usage data collection of any kind.
-
-* No user trading information collected or sold.
-
-* Runs 100% on uncompiled code anyone can read and audit.
-
-# Superalgos Development Pipeline
-
-* **Superalgos P2P Network:** Will allow the project to distribute trading intelligence produced by algo-traders.
-
-* **Trading Signals:** Will allow providers to broadcast trading signals and be rewarded with SA Tokens.
-
-* **Superalgos Mobile:** Will allow users to consume trading signals for free and autonomously execute trades from their mobile phones.
-
-* **Ethereum Integration:** Will allow mining data from an Ethereum network node, and bring it into the Superalgos workflow.
-
-# What is the Superalgos Platform?
-
-Superalgos Platform is a set of tools to automate crypto-trading. It is implemented as a Node JS Client + Web App that runs on your hardware and scales from a single Raspberry Pi to a Trading Farm. The Platform is fully functional and has been used for trading live since 2020. 
+Superalgos Platform is a set of tools to automate crypto-trading. It is implemented as a Node JS Client + Web App that runs on your hardware and scales from a single Raspberry Pi to a Trading Farm. The Platform is fully functional and has been used for trading live since 2020.
 
 At Beta 12, trading signals will be able to be sent to the Suerpalgos Network from the Superalgos Platform.
 
-## Superalgos Platform Features
+### Superalgos Platform Features
 
-* A Visual Scripting Designer.
-* Integrated Charting System.
-* A Visual Strategy Debugger.
-* Data Mining Tools.
-* Coordinated Task Management across a Trading Farm.
-* Community-built strategies to learn and start from.
-* TensorFlow Machine Learning integration. 
-* In-App Tutorials.
-* Complete In-App Documentation.
-* SA Token / Project Governance System.
+- A Visual Scripting Designer.
+- Integrated Charting System.
+- A Visual Strategy Debugger.
+- Data Mining Tools.
+- Coordinated Task Management across a Trading Farm.
+- Community-built strategies to learn and start from.
+- TensorFlow Machine Learning integration.
+- In-App Tutorials.
+- Complete In-App Documentation.
+- SA Token / Project Governance System.
+  
+### Superalgos Development Pipeline
 
-## Superalgos Platform Allows You To...
+- **Superalgos P2P Network:** Will allow the project to distribute trading intelligence produced by algo-traders.
+- **Trading Signals:** Will allow providers to broadcast trading signals and be rewarded with SA Tokens.
+- **Superalgos Mobile:** Will allow users to consume trading signals for free and autonomously execute trades from their mobile phones.
+- **Ethereum Integration:** Will allow mining data from an Ethereum network node, and bring it into the Superalgos workflow.
 
-* Visually design your trading strategies.
-* Visually debug your trading strategies.
-* Visually design your indicators.
-* Visually design your plotters to visualize indicators or mined data.
-* Visually design your data-mining operations.
-* Download historical market data from crypto exchanges.
-* Backtest your strategies against historical data.
-* Run live trading sessions.
-* Run arbitrary data-mining operations of any size.
-* Feed your trading strategies with the data mined.
-* Use your token holdings to vote and influence the direction of the project development.
-* Produce real-time trading signals and send them via the p2p network. (under development)
+### Superalgos is User-centric
 
-# Superalgos Platform for Developers
+- No ads, anywhere.
+- No sign-up / logins.
+- No user/usage data collection of any kind.
+- No user trading information collected or sold.
+- Runs 100% on uncompiled code anyone can read and audit.
 
-* You may use Superalgos as a platform or as a component of a larger system.
-* No proprietary code/libraries. All open-source and free.
-* Superalgos features a library of community-contributed plugins (workspaces, strategies, indicators, plotters, tutorials, etc.).
+### Superalgos Platform Allows You To
 
-## Superalgos Platform Saves You Time
+- Visually design your trading strategies.
+- Visually debug your trading strategies.
+- Visually design your indicators.
+- Visually design your plotters to visualize indicators or mined data.
+- Visually design your data-mining operations.
+- Download historical market data from crypto exchanges.
+- Backtest your strategies against historical data.
+- Run live trading sessions.
+- Run arbitrary data-mining operations of any size.
+- Feed your trading strategies with the data mined.
+- Use your token holdings to vote and influence the direction of the project development.
+- Produce real-time trading signals and send them via the p2p network. (under development)
 
-* No need to code the download of historical data from crypto exchanges.
-* No need to code the streaming of market data from crypto exchanges.
-* No need to hardcode strategies. Use the visual designer for a more flexible approach.
-* No need to debug what went wrong, line by line, or dive into log files with tons of data. You can see each variable of the state of the Trading Engine at every candle by hovering the mouse over the charts.
-* No need to integrate a charting library, Superalgos features an integrated Charting System.
-* No need to manage task data or execution dependencies. Superalgos allows you to define Tasks and distribute them across a Trading Farm and takes care of the data and execution dependencies so that each task automatically starts when their dependencies are ready.
+### Superalgos Platform for Developers
 
-## Superalgos Platform is Permissionless
+- You may use Superalgos as a platform or as a component of a larger system.
+- No proprietary code/libraries. All open-source and free.
+- Superalgos features a library of community-contributed plugins (workspaces, strategies, indicators, plotters, tutorials, etc.).
 
-* Don't like the UI?
-* Don't like the icons used?
-* Don't like the Charting System?
-* Don't like the Visual Designer?
-* Don't like the Visual Debugger?
-* Don't like the Docs?
-* Don't like the Trading Bot?
-* Don't like the Indicators?
-* Don't like the Plotters?
-* Don't like any other part of the system?
+### Superalgos Platform Saves You Time
+
+- No need to code the download of historical data from crypto exchanges.
+- No need to code the streaming of market data from crypto exchanges.
+- No need to hardcode strategies. Use the visual designer for a more flexible approach.
+- No need to debug what went wrong, line by line, or dive into log files with tons of data. You can see each variable of the state of the Trading Engine at every candle by hovering the mouse over the charts.
+- No need to integrate a charting library, Superalgos features an integrated Charting System.
+- No need to manage task data or execution dependencies. Superalgos allows you to define Tasks and distribute them across a Trading Farm and takes care of the data and execution dependencies so that each task automatically starts when their dependencies are ready.
+
+### Superalgos Platform is Permissionless
+
+- Don't like the UI?
+- Don't like the icons used?
+- Don't like the Charting System?
+- Don't like the Visual Designer?
+- Don't like the Visual Debugger?
+- Don't like the Docs?
+- Don't like the Trading Bot?
+- Don't like the Indicators?
+- Don't like the Plotters?
+- Don't like any other part of the system?
 
 No problem, code or integrate libraries with your own version of any component and we promise we will merge your work and provide it as an alternative to users. We believe in Permissionless Innovation and that users, not team members, are the final judges and the ones who decide what they prefer to use. You are free to create an alternative for any part of the system that you believe that should work or should have been done in a different way. We will help you integrate your vision into the next release and enable a way for users to choose between different implementations of the same functionality. You will also be granted the title of maintainer of the functionality you provide and have decision power on how it evolves in the future.
 
-# Superalgos Platform for Algo-Trders
+### Superalgos Platform for Algo-Trders
 
-* Superalgos is easy to install/uninstall.
-* Superalgos is easy to run.
-* Superalgos is easy to use.
-* Superalgos is easy to learn.
-* Superalgos is easy to debug.
-* Superalgos is well documented.
-* You have free online support via Telegram and Discord.
+- Superalgos is easy to install/uninstall.
+- Superalgos is easy to run.
+- Superalgos is easy to use.
+- Superalgos is easy to learn.
+- Superalgos is easy to debug.
+- Superalgos is well documented.
+- You have free online support via Telegram and Discord.
 
-## Superalgos Platform Saves You Money
+### Superalgos Platform Saves You Money
 
-* There are no paid plans or anything that costs you money.
-* There is no locked functionality. You may use the full capacity of the software.
-* There is no limit to the number of backtests you may run.
-* There is no limit to the number of live sessions you may run.
-* There is no limit to the number of historical data you may download.
-* There is no limit to the volume of data you may process.
-* You may use all the plugins available (indicators, plotters, strategies, etc.)
-* You may install Superalgos in as many machines as you wish.
-* Your installations may be used by as many people as required.
-* You may connect to as many crypto exchanges as you wish.
+- There are no paid plans or anything that costs you money.
+- There is no locked functionality. You may use the full capacity of the software.
+- There is no limit to the number of backtests you may run.
+- There is no limit to the number of live sessions you may run.
+- There is no limit to the number of historical data you may download.
+- There is no limit to the volume of data you may process.
+- You may use all the plugins available (indicators, plotters, strategies, etc.)
+- You may install Superalgos in as many machines as you wish.
+- Your installations may be used by as many people as required.
+- You may connect to as many crypto exchanges as you wish.
 
-## Superalgos Platform Minimizes Risks
+### Superalgos Platform Minimizes Risks
 
-* No one can know what strategies you design/run.
-* No one can front-run you.
-* No one can steal your trading ideas.
-* No one knows how much capital you trade.
-* No one can see your exchange keys.
+- No one can know what strategies you design/run.
+- No one can front-run you.
+- No one can steal your trading ideas.
+- No one knows how much capital you trade.
+- No one can see your exchange keys.
 
-# Superalgos Platform for Companies
+### Superalgos Platform for Companies
 
-* No need to buy expensive software for monitoring crypto markets or trading execution.
-* No need to hire your own developers.
-* All your employees can use Superalgos for free.
-* You can use Superalgos to its full capacity or just the features you are currently interested in.
-* Superalgos may be integrated into your existing operation, feeding to and from other systems.
-* You've got a growing community of algo-traders constantly improving the software at zero cost for you.
-* You've got free online customer support via Telegram or Discord. 
+- No need to buy expensive software for monitoring crypto markets or trading execution.
+- No need to hire your own developers.
+- All your employees can use Superalgos for free.
+- You can use Superalgos to its full capacity or just the features you are currently interested in.
+- Superalgos may be integrated into your existing operation, feeding to and from other systems.
+- You've got a growing community of algo-traders constantly improving the software at zero cost for you.
+- You've got free online customer support via Telegram or Discord.
 
-# Support
+## Support
 
 We just opened a brand new [Discord server for Support and the Community](https://discord.gg/CGeKC6WQQb).
 
 We also meet on several Telegram groups, where it all started!
 
 > **BEWARE OF IMPERSONATORS — SCAMMERS ARE LURKING!**
-Superalgos Admins, the Core Team, and Community Mods will never contact you directly unless you contact them first. We will never ask you for API keys, coins, or cash. In fact, we will never ask you to trust us in any way. Our [Community Safety Policy](https://superalgos.org/community-safety-policy.shtml) explains why. In short, we want to make it clear that if someone contacts you directly claiming to work with or for the project, it is a scam. Please report scammers in the Community group so that they may be banned, and to increase awareness of the problem, but also block them and report them to Telegram if the option is available.
+> 
+> Superalgos Admins, the Core Team, and Community Mods will never contact you directly unless you contact them first. We will never ask you for API keys, coins, or cash. In fact, we will never ask you to trust us in any way. Our [Community Safety Policy](https://superalgos.org/community-safety-policy.shtml) explains why. In short, we want to make it clear that if someone contacts you directly claiming to work with or for the project, it is a scam. Please report scammers in the Community group so that they may be banned, and to increase awareness of the problem, but also block them and report them to Telegram if the option is available.
 
-## Via Telegram
+- Via Telegram
+  - Online support through our [Superalgos User's Support Group](https://t.me/superalgossupport).
+- In-App Integrated Documentation
+  - Superalgos features interactive documentation built-in the system.
+- Video Tutorials
+  - Subscribe to the [Superalgos YouTube Channel](https://www.youtube.com/channel/UCmYSGbB151xFQPNxj7KfKBg).
+- In-App Tutorials
+  - There are many interactive tutorials you may do and learn from.
 
-Online support through our [Superalgos User's Support Group](https://t.me/superalgossupport).
+## Other Resources
 
-## In-App Integrated Documentation
+- Web Site
+  - For an overview of what Superalgos can do for you, check the [Superalgos Website](https://superalgos.org/).
+- Telegram
+  - For official news, join the [Superalgos Announcements Channel](https://t.me/superalgos).
+  - Meet other users in the [Superalgos Telegram Community Group](https://t.me/superalgoscommunity).
+  - Meet developers in the [Superalgos Telegram Developer's Group](https://t.me/superalgosdevelop).
+  - Users meet in other topic-specific Telegram Groups. There's a [complete list of groups](https://superalgos.org/community-join.shtml) on the website.
+- Blog
+  - Find official announcements and various articles on the [Superalgos Blog](https://medium.com/superalgos).
+- Twitter
+  - To stay in the loop, follow [Superalgos on Twitter](https://twitter.com/superalgos).
+- Facebook
+  - Or follow [Superalgos on Facebook](https://www.facebook.com/superalgos).
 
-Superalgos features interactive documentation built-in the system.
-
-## Video Tutorials
-
-Subscribe to the [Superalgos YouTube Channel](https://www.youtube.com/channel/UCmYSGbB151xFQPNxj7KfKBg).
-
-## In-App Tutorials
-
-There are many interactive tutorials you may do and learn from.
-
-# Other Resources
-
-## Web Site
-
-For an overview of what Superalgos can do for you, check the [Superalgos Website](https://superalgos.org/).
-
-## Telegram
-
-For official news, join the [Superalgos Announcements Channel](https://t.me/superalgos).
-
-Meet other users in the [Superalgos Telegram Community Group](https://t.me/superalgoscommunity).
-
-Meet developers in the [Superalgos Telegram Developer's Group](https://t.me/superalgosdevelop).
-
-Users meet in other topic-specific Telegram Groups. There's a [complete list of groups](https://superalgos.org/community-join.shtml) on the website.
-
-## Blog
-
-Find official announcements and various articles on the [Superalgos Blog](https://medium.com/superalgos).
-
-## Twitter
-
-To stay in the loop, follow [Superalgos on Twitter](https://twitter.com/superalgos).
-
-## Facebook
-
-Or follow [Superalgos on Facebook](https://www.facebook.com/superalgos).
-
-# Contributing
+## Contributing
 
 Superalgos is a Community Project built by users for users. Learn [how you may contribute](https://superalgos.org/community-contribute.shtml).
 
-# License
+## License
 
 Superalgos is open-source software released under [Apache License 2.0](LICENSE).

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "author": {
     "name": "Luis-Fernando-Molina"
   },
+  "scripts": {
+    "start": "node platform minMemo noBrowser",
+    "setup": "node setup noShortcuts"
+  },
   "dependencies": {
     "@octokit/rest": "^18.11.4",
     "ccxt": "^1.57.36",


### PR DESCRIPTION
- add table of contents to main readme
- clean up a few sections of the main readme
- move docker directions and info out to it's own readme
- add a Brewfile to quickly install requirements on Mac OS with Homebrew
- add a couple quick scripts to `package.json`
  - the `package.json` can function similar to a `Makefile`
  - `npm run setup` will execute `node setup noShortcuts`
  - `npm start` will execute `node platform minMemo noBrowser` 
- change docker-compose to use `user` instead of trying to set uid/gid via env vars which didn't work to ensure file persistence works