### PR TITLE
Contribution: Accept webSocketsExternalURL parameter on network node config

### DIFF
--- a/Platform/UI/EventsServerClient.js
+++ b/Platform/UI/EventsServerClient.js
@@ -219,7 +219,6 @@ function newEventsServerClient(lanNetworkNode) {
             let host
             let port
             let extwsurl
-            /* At this point the node does not have the payload property yet, that is why we have to do this manually */
             try {
                 let config = JSON.parse(lanNetworkNode.config)
                 host = config.host


### PR DESCRIPTION
When hosting the platform on a SSL server, websockets requests must be SSL too. The purpose of this PR is to accept an additional "webSocketsExternalURL" parameter provided by end user for activating wss.