### PR TITLE
update workflow to create a docker image off releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,9 +2,14 @@ name: Publish Docker image
 
 on: 
   push:
-    branches: [master, develop]
-    release:
-      types: [published, created, edited]
+    branches:
+      - master
+      - develop
+  release:
+    types:
+      - published
+      - created
+      - edited
 
 jobs:
   publish:


### PR DESCRIPTION
effectively update the whitespace to move the 'release' to a different level.