### PR TITLE
add special setup stages to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "scripts": {
     "start": "node platform minMemo noBrowser",
+    "presetup": "git checkout develop && git pull upstream develop",
     "setup": "node setup noShortcuts",
+    "postsetup": "npm start",
     "dist": "electron-builder -c build/electron-builder.json",
     "postinstall": "electron-builder install-app-deps"
   },


### PR DESCRIPTION
- add `presetup` stage in the scripts section which will check out develop, pull the upstream (Superalgos/Superalgos) code in order to update the local fork
- add `postsetup` stage which will execute `npm start` which is an alias for `node platform minMemo noBrowser`
- with these, executing `npm run setup` will result in the code being refreshed, new node modules being installed, and then the platform started.

more info : https://docs.npmjs.com/cli/v7/using-npm/scripts