### PR TITLE
set brokerid for okex

### DIFF
--- a/Projects/Algorithmic-Trading/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/APIs/ExchangeAPI.js
+++ b/Projects/Algorithmic-Trading/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/APIs/ExchangeAPI.js
@@ -24,6 +24,7 @@
         tradingSystem = TS.projects.foundations.globals.processVariables.VARIABLES_BY_PROCESS_INDEX_MAP.get(processIndex).SIMULATION_STATE.tradingSystem
   
         exchangeId = TS.projects.foundations.globals.taskConstants.TASK_NODE.parentNode.parentNode.parentNode.referenceParent.parentNode.parentNode.config.codeName
+        options = TS.projects.foundations.globals.taskConstants.TASK_NODE.parentNode.parentNode.parentNode.referenceParent.parentNode.parentNode.config.options
   
         let key
         let secret
@@ -37,7 +38,6 @@
                 secret = TS.projects.foundations.globals.taskConstants.TASK_NODE.keyReference.referenceParent.config.secret
                 uid = TS.projects.foundations.globals.taskConstants.TASK_NODE.keyReference.referenceParent.config.uid
                 password = TS.projects.foundations.globals.taskConstants.TASK_NODE.keyReference.referenceParent.config.password
-                options = TS.projects.foundations.globals.taskConstants.TASK_NODE.keyReference.referenceParent.config.options
             }
         }
 

--- a/Projects/Algorithmic-Trading/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/APIs/ExchangeAPI.js
+++ b/Projects/Algorithmic-Trading/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/APIs/ExchangeAPI.js
@@ -29,7 +29,6 @@
         let secret
         let uid
         let password
-        let brokerId
         let sandBox = TS.projects.foundations.globals.taskConstants.TASK_NODE.parentNode.parentNode.parentNode.referenceParent.parentNode.parentNode.config.sandbox || false;
   
         if (TS.projects.foundations.globals.taskConstants.TASK_NODE.keyReference !== undefined) {
@@ -38,7 +37,7 @@
                 secret = TS.projects.foundations.globals.taskConstants.TASK_NODE.keyReference.referenceParent.config.secret
                 uid = TS.projects.foundations.globals.taskConstants.TASK_NODE.keyReference.referenceParent.config.uid
                 password = TS.projects.foundations.globals.taskConstants.TASK_NODE.keyReference.referenceParent.config.password
-                brokerId = TS.projects.foundations.globals.taskConstants.TASK_NODE.keyReference.referenceParent.config.brokerId
+                options = TS.projects.foundations.globals.taskConstants.TASK_NODE.keyReference.referenceParent.config.options
             }
         }
 
@@ -46,12 +45,11 @@
             case 'okex':
             case 'okex3':
             case 'okex5':
-                if (brokerId === undefined) {
-                    brokerId = 'c77ccd60ec7b4cBC'
+                if (options.brokerId === undefined) {
+                    options.brokerId = 'c77ccd60ec7b4cBC'
                 }
                 break;
         }
-        options.brokerId = brokerId
 
         const exchangeClass = ccxt[exchangeId]
         const exchangeConstructorParams = {

--- a/Projects/Algorithmic-Trading/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/APIs/ExchangeAPI.js
+++ b/Projects/Algorithmic-Trading/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/APIs/ExchangeAPI.js
@@ -29,6 +29,7 @@
         let secret
         let uid
         let password
+        let brokerId
         let sandBox = TS.projects.foundations.globals.taskConstants.TASK_NODE.parentNode.parentNode.parentNode.referenceParent.parentNode.parentNode.config.sandbox || false;
   
         if (TS.projects.foundations.globals.taskConstants.TASK_NODE.keyReference !== undefined) {
@@ -37,8 +38,21 @@
                 secret = TS.projects.foundations.globals.taskConstants.TASK_NODE.keyReference.referenceParent.config.secret
                 uid = TS.projects.foundations.globals.taskConstants.TASK_NODE.keyReference.referenceParent.config.uid
                 password = TS.projects.foundations.globals.taskConstants.TASK_NODE.keyReference.referenceParent.config.password
+                brokerId = TS.projects.foundations.globals.taskConstants.TASK_NODE.keyReference.referenceParent.config.brokerId
             }
         }
+
+        switch (exchangeId) {
+            case 'okex':
+            case 'okex3':
+            case 'okex5':
+                if (brokerId === undefined) {
+                    brokerId = 'c77ccd60ec7b4cBC'
+                }
+                break;
+        }
+        options.brokerId = brokerId
+
         const exchangeClass = ccxt[exchangeId]
         const exchangeConstructorParams = {
             'apiKey': key,


### PR DESCRIPTION
use a static broker id for okex, overriding the default value provided by the CCXT library. This value can also be overriden in the workspace by adding a `"brokerId"` field to the API Key json.