### PR TITLE
Optional-dependencies

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY . .
 RUN apk add --no-cache --virtual .build-deps make g++ \
     && apk add --no-cache python3 \
-    && if [ "$(uname -m)" = "x86_64" ]; then node setup noShortcuts tensorflow; else node setup noShortcuts; fi \
+    && npm ci \
     && mkdir -p ./Platform/My-Data-Storage ./Platform/My-Log-Files ./Platform/My-Workspaces \
     && addgroup superalgos \
     && adduser --disabled-password --no-create-home --ingroup superalgos superalgos \

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "twitter": "^1.7.1",
     "util": "^0.12.4",
     "web3": "^1.6.0",
-    "ws": "^8.2.3",
+    "ws": "^8.2.3"
+  },
+  "optionalDependencies": {
     "@tensorflow/tfjs-node": "^2.8.6"
   },
   "devDependencies": {


### PR DESCRIPTION
https://docs.npmjs.com/cli/v8/configuring-npm/package-json#optionaldependencies

> If a dependency can be used, but you would like npm to proceed if it cannot be found or fails to install, then you may put it in the optionalDependencies object. This is a map of package name to version or url, just like the dependencies object. The difference is that build failures do not cause installation to fail.