### PR TITLE
patch for desktop launcher bug GH #3163

### DIFF
--- a/Launch-Scripts/create-shortcut.js
+++ b/Launch-Scripts/create-shortcut.js
@@ -59,7 +59,7 @@ if (os.platform() == "win32") {
             Name=${name}
             Comment=Launch Shortcut for Superalgos 
             Path=${__dirname}
-            Exec=gnome-terminal -e ${__dirname}/launch-linux-mac.sh
+            Exec=${__dirname}/launch-linux-mac.sh
             Terminal=true
             Icon=${icon}
             Categories=Application;`,


### PR DESCRIPTION
This change fixes bug #3163, regarding hard coding `gnome-terminal` into the desktop launch command. I believe it is unnecessary to specify a terminal, and simply removed the explicit reference. Confirmed that this patch fixes the issue for my local Xubuntu install.