### PR TITLE
update if statement in tf setup so it only executes when specific conditions are met

### DIFF
--- a/tf_setup.js
+++ b/tf_setup.js
@@ -4,13 +4,15 @@ const path = require('path')
 const srcFolder = './node_modules/@tensorflow/tfjs-node/deps/lib/'
 const destFolder = './node_modules/@tensorflow/tfjs-node/lib/'
 
-const dest = fs.readdirSync(destFolder, { withFileTypes: true })
-.filter(dirent => dirent.isDirectory())
-.map(dirent => dirent.name)
+if (process.platform === 'win32'
+    && fs.existsSync(srcFolder) 
+    && fs.existsSync(destFolder)) {
+        const dest = fs.readdirSync(destFolder, { withFileTypes: true })
+        .filter(dirent => dirent.isDirectory())
+        .map(dirent => dirent.name)
 
-if(process.platform === 'win32') {
-    fs.copyFile(path.join(srcFolder, "tensorflow.dll"), path.join(destFolder, dest[0], "tensorflow.dll"), (err) => {
-        if (err) throw err
-        console.log("tensorflow dll copied")
-    })
+        fs.copyFile(path.join(srcFolder, "tensorflow.dll"), path.join(destFolder, dest[0], "tensorflow.dll"), (err) => {
+            if (err) throw err
+            console.log("tensorflow dll copied")
+        })
 }


### PR DESCRIPTION
- tensorflow is an optional install so it does not always get installed.
- the tf-setup script currently causes errors when tensoflow isn't installed
- checking for the presence of the folders and the correct platform first ensures the script can run safely in all cases.