### PR TITLE
Added German Telegram group link in the footer

### DIFF
--- a/Projects/Education/UI/Spaces/Docs-Space/Footer.js
+++ b/Projects/Education/UI/Spaces/Docs-Space/Footer.js
@@ -244,6 +244,7 @@ function newFoundationsDocsFooter() {
         HTML = HTML + '<li><a href="https://t.me/superalgos_es" target="_blank">Spanish</a></li>'
         HTML = HTML + '<li><a href="https://t.me/superalgos_ru" target="_blank">Russian</a></li>'
         HTML = HTML + '<li><a href="https://t.me/tr_superalgos" target="_blank">Turkish</a></li>'
+        HTML = HTML + '<li><a href="https://t.me/superalgos_de" target="_blank">German</a></li>'
         HTML = HTML + '</ul>'
         HTML = HTML + '<h4>Other Resources</h4>'
         HTML = HTML + '<ul>'


### PR DESCRIPTION
I have added the german telegram group lonk to the footer as it was missing there. I copied the code from another group link and inserted the german telegram group link into the space as well as German where the Telegram group name stands.