### PR TITLE
New node action Highlight Referencing Nodes

### DIFF
--- a/Projects/Foundations/UI/Spaces/Floating-Space/UiObject.js
+++ b/Projects/Foundations/UI/Spaces/Floating-Space/UiObject.js
@@ -34,6 +34,8 @@ function newUiObject() {
         percentageAngleOffset: 0,
         statusAtAngle: false,
         statusAngleOffset: 0,
+        highlightReferenceChildren: false,
+        drawReferenceLine: false,
         run: run,
         stop: stop,
         heartBeat: heartBeat,
@@ -1564,7 +1566,7 @@ function newUiObject() {
     }
 
     function drawReferenceLine() {
-        if (UI.projects.foundations.spaces.floatingSpace.drawReferenceLines === false && thisObject.isOnFocus === false) { return }
+        if (UI.projects.foundations.spaces.floatingSpace.drawReferenceLines === false && thisObject.drawReferenceLine === false && thisObject.isOnFocus === false) { return }
         if (thisObject.payload.referenceParent === undefined) { return }
         if (thisObject.payload.referenceParent.payload === undefined) { return }
         if (thisObject.payload.referenceParent.payload.floatingObject === undefined) { return }
@@ -2253,6 +2255,9 @@ function newUiObject() {
             function drawHighlighted() {
                 if (isHighlighted === true) {
                     VISIBLE_RADIUS = thisObject.payload.floatingObject.container.frame.radius
+                    if (UI.projects.foundations.spaces.floatingSpace.inMapMode === true) {
+                        VISIBLE_RADIUS = UI.projects.foundations.spaces.floatingSpace.transformRadiusToMap(VISIBLE_RADIUS)
+                    }
                     let OPACITY = highlightCounter / 10
 
                     browserCanvasContext.beginPath()

--- a/Projects/Foundations/UI/Spaces/Floating-Space/UiObjectConstructor.js
+++ b/Projects/Foundations/UI/Spaces/Floating-Space/UiObjectConstructor.js
@@ -453,8 +453,22 @@ function newUiObjectConstructor() {
                 }
             )
         }
-
         menuItemsInitialValues.push(
+            {
+                action: 'Highlight Referencing Nodes',
+                actionFunction: floatingObject.payload.executeAction,
+                actionProject: 'Visual-Scripting',
+                label: undefined,
+                visible: true,
+                iconPathOn: 'highlight-referencing-nodes-on',
+                iconPathOff: 'highlight-referencing-nodes-off',
+                rawRadius: 12,
+                targetRadius: 0,
+                currentRadius: 0,
+                ring: 3
+            }
+        )
+    menuItemsInitialValues.push(
             {
                 action: 'Open Documentation',
                 actionFunction: floatingObject.payload.executeAction,

--- a/Projects/ProjectsSchema.json
+++ b/Projects/ProjectsSchema.json
@@ -454,7 +454,7 @@
                     "functionName": "newVisualScriptingFunctionLibraryNodePath"
                 },
                 {
-                    "name": "Highlight Reference Children",
+                    "name": "Reference Children",
                     "propertyName": "referenceChildren",
                     "functionName": "newVisualScriptingNodeActionFunctionReferenceChildren"
                 }

--- a/Projects/ProjectsSchema.json
+++ b/Projects/ProjectsSchema.json
@@ -452,6 +452,11 @@
                     "name": "Node Path",
                     "propertyName": "nodePath",
                     "functionName": "newVisualScriptingFunctionLibraryNodePath"
+                },
+                {
+                    "name": "Highlight Reference Children",
+                    "propertyName": "referenceChildren",
+                    "functionName": "newVisualScriptingNodeActionFunctionReferenceChildren"
                 }
             ],
             "systemActionFunctions": [],

--- a/Projects/Visual-Scripting/UI/Node-Action-Functions/NodeActionSwitch.js
+++ b/Projects/Visual-Scripting/UI/Node-Action-Functions/NodeActionSwitch.js
@@ -347,6 +347,23 @@ function newVisualScriptingNodeActionSwitch() {
                     UI.projects.workspaces.spaces.designSpace.workspace.buildSystemMenu() 
                 }
                 break
+            case 'Highlight Referencing Nodes':
+                {
+                    UI.projects.visualScripting.nodeActionFunctions.referenceChildren.toggleHighlightReferenceChildren(action.node)
+                    /* if (action.node.payload.uiObject.referencingNodesAreHighlighted === false) {
+                        action.node.payload.uiObject.referencingNodesAreHighlighted = true
+                        for (let child of Array.from(action.node.payload.referenceChildren, ([id, node]) => (node))) {
+                            child.payload.floatingObject.unCollapseParent()
+                            child.payload.uiObject.keepHighlighted = true
+                        }
+                    } else {
+                        action.node.payload.uiObject.referencingNodesAreHighlighted = false
+                        for (let child of Array.from(action.node.payload.referenceChildren, ([id, node]) => (node))) {
+                            child.payload.uiObject.keepHighlighted = false
+                        }
+                    } */
+                }
+                break
             default: {
                 console.log("[WARN] Action sent to Visual-Scripting Action Switch does not belong here. Verify at the App Schema file of the node that triggered this action that the actionProject is pointing to the right project. -> Action = " + action.name + " -> Action Node Name = " + action.node.name)
             }

--- a/Projects/Visual-Scripting/UI/Node-Action-Functions/NodeActionSwitch.js
+++ b/Projects/Visual-Scripting/UI/Node-Action-Functions/NodeActionSwitch.js
@@ -350,18 +350,6 @@ function newVisualScriptingNodeActionSwitch() {
             case 'Highlight Referencing Nodes':
                 {
                     UI.projects.visualScripting.nodeActionFunctions.referenceChildren.toggleHighlightReferenceChildren(action.node)
-                    /* if (action.node.payload.uiObject.referencingNodesAreHighlighted === false) {
-                        action.node.payload.uiObject.referencingNodesAreHighlighted = true
-                        for (let child of Array.from(action.node.payload.referenceChildren, ([id, node]) => (node))) {
-                            child.payload.floatingObject.unCollapseParent()
-                            child.payload.uiObject.keepHighlighted = true
-                        }
-                    } else {
-                        action.node.payload.uiObject.referencingNodesAreHighlighted = false
-                        for (let child of Array.from(action.node.payload.referenceChildren, ([id, node]) => (node))) {
-                            child.payload.uiObject.keepHighlighted = false
-                        }
-                    } */
                 }
                 break
             default: {

--- a/Projects/Visual-Scripting/UI/Node-Action-Functions/ReferenceChildren.js
+++ b/Projects/Visual-Scripting/UI/Node-Action-Functions/ReferenceChildren.js
@@ -1,0 +1,35 @@
+function newVisualScriptingNodeActionFunctionReferenceChildren () {
+    let thisObject = {
+        toggleHighlightReferenceChildren: toggleHighlightReferenceChildren
+    }
+
+    return thisObject
+
+    function toggleHighlightReferenceChildren(node) {
+        if (node.payload.referenceChildren === undefined) {
+            node.payload.uiObject.setInfoMessage('This node is not referenced by any other nodes')
+            return
+        }
+        let referenceChildren = Array.from(node.payload.referenceChildren, ([id, node]) => (node))
+        let numberOfChildren = referenceChildren.length
+        if (numberOfChildren === 0) {
+            node.payload.uiObject.setInfoMessage('This node is not referenced by any other nodes')
+            return
+        }
+        if (node.payload.uiObject.highlightReferenceChildren === false) {
+            node.payload.uiObject.highlightReferenceChildren = true
+            node.payload.uiObject.setInfoMessage(`Highlighting ${numberOfChildren} referencing nodes`)
+            for (let child of referenceChildren) {
+                child.payload.floatingObject.unCollapseParent()
+                child.payload.uiObject.drawReferenceLine = true
+                child.payload.uiObject.highlight(VERY_LARGE_NUMBER)
+            }
+        } else {
+            node.payload.uiObject.highlightReferenceChildren = false
+            for (let child of referenceChildren) {
+                child.payload.uiObject.drawReferenceLine = false
+                child.payload.uiObject.highlight(0)
+            }
+        }
+    }
+}


### PR DESCRIPTION
An on/off switch in the UI object menu to highlight referencing nodes and draw their reference lines. This is a corollary of the work done on undo/redo functionality.