### PR TITLE
always always checkout develop on setup

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -254,7 +254,7 @@ nodeInstPromise.then(() => {
       if (!developExists) await git.checkout(['-B', 'develop'])
       // Check that a branch is checked out, otherwise checkout develop
       branchSumAll = await git.branchLocal().catch(errorResp)
-      if (branchSumAll.current === '') await git.checkout(['-B', 'develop'])
+      if (branchSumAll.current === '' || branchSumAll.current === 'master') await git.checkout(['-B', 'develop'])
 
       if (repo !== "Superalgos" && origin && gitUser) await git.removeRemote('origin').catch(errorResp)
       if (repo !== "Superalgos" && gitUser) {


### PR DESCRIPTION
If user was on master, node setup explicitly changes them to develop branch of plugins.