### PR TITLE
Education: Making DocumentPage.js more resilient against wrong config…

### DIFF
--- a/Projects/Education/UI/Spaces/Docs-Space/DocumentPage.js
+++ b/Projects/Education/UI/Spaces/Docs-Space/DocumentPage.js
@@ -1319,7 +1319,8 @@ function newFoundationsDocsDocumentPage() {
                     let propertyMap = new Map()
                     for (let i = 0; i < allNodesFound.length; i++) {
                         let node = allNodesFound[i]
-                        let config = JSON.parse(node.config)
+                        let config = {}
+                        try { config = JSON.parse(node.config) } catch(e) {}
                         for (const property in config) {
                             let value = JSON.stringify(config[property], undefined, 4)
                             let valueArray = propertyMap.get(property)


### PR DESCRIPTION
…s - fixes #3788

When a user profile had an invalid configuration for a node (e.g. configuration empty instead of {} ), DocumentPage.js died with an error. This commit introduces a try-catch-block to catch errors during JSON parsig.