### PR TITLE
Fixes and Adds. Will write a comment on GitHub

### DIFF
--- a/Projects/Algorithmic-Trading/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/OrdersCalculations.js
+++ b/Projects/Algorithmic-Trading/TS/Bot-Modules/Trading-Bot/Low-Frequency-Trading/OrdersCalculations.js
@@ -18,6 +18,7 @@ exports.newAlgorithmicTradingBotModulesOrdersCalculations = function (processInd
     let tradingEngine
     let tradingSystem
     let sessionParameters
+    let exchangeConfig = TS.projects.foundations.globals.taskConstants.TASK_NODE.parentNode.parentNode.parentNode.referenceParent.parentNode.parentNode.config
 
     return thisObject
 
@@ -34,7 +35,11 @@ exports.newAlgorithmicTradingBotModulesOrdersCalculations = function (processInd
     }
 
     async function actualSizeCalculation(tradingEngineStage, tradingSystemOrder, tradingEngineOrder, order, applyFeePercentage) {
-        /* 
+        /* April 2022 - A NOTE ON THE COMMENT BELOW:
+        Actually there are exchanges where is possible to trade inverse, usually on swap/perpetuals pairs.
+        It means that the following is not strictly true any more */
+
+        /*
         When we submit the order to the exchange, we do it specifying the order size
         in Base Asset. It is mandatory to be in Base Asset as per CCXT Library API and
         probably as per the Exchange API too. 
@@ -56,7 +61,33 @@ exports.newAlgorithmicTradingBotModulesOrdersCalculations = function (processInd
 
         if ( order.amount !== undefined) {
             /* We receive the actual size from the exchange at the order.amount field. */
-            tradingEngineOrder.orderBaseAsset.actualSize.value = order.amount
+            // ORIGINAL tradingEngineOrder.orderBaseAsset.actualSize.value = order.amount // Left just in case .. 
+            
+            // Here we check if the market is inverse 
+            // Example BTC/USD:BTC -> Calcs must be made for baseAsset in this case because
+            // the contract is an inverse contract and is settled in base currency
+            // If the market is spot or linear then baseAsset is equal to order.amount
+
+            if (exchangeConfig.options !== undefined) {
+                if (exchangeConfig.options.defaultType !== undefined) {
+                    defaultType = exchangeConfig.options.defaultType
+    
+                    if (defaultType == 'inverse') {
+                        tradingEngineOrder.orderBaseAsset.actualSize.value = order.amount / order.average
+                        
+                    } else {
+                        tradingEngineOrder.orderBaseAsset.actualSize.value = order.amount
+                        
+                    } 
+                }
+            }  else {tradingEngineOrder.orderBaseAsset.actualSize.value = order.amount}
+
+
+            // Uncomment when debuggingconsole.log ()
+            // console.log ('The order placed in OrdersCalculation is:')
+            // console.log (order)
+
+
         }
 
         recalculateActualSize()
@@ -122,12 +153,50 @@ exports.newAlgorithmicTradingBotModulesOrdersCalculations = function (processInd
             We will use the average whenever is available. As of today it is not 100% clear when this is
             available, but it seems sometimes it is not. In those cases we use the price.
             */
-            tradingEngineOrder.orderStatistics.actualRate.value = order.average
+            // ORIGINAL tradingEngineOrder.orderStatistics.actualRate.value = order.average
+
+            // Here we check if the market is inverse 
+            // Example BTC/USD:BTC -> Calcs must be made for baseAsset in this case because
+            // the contract is an inverse contract and is settled in base currency
+            
+            if (exchangeConfig.options !== undefined) {
+                if (exchangeConfig.options.defaultType !== undefined) {
+                    defaultType = exchangeConfig.options.defaultType
+    
+                    if (defaultType == 'inverse') {
+                        tradingEngineOrder.orderStatistics.actualRate.value = order.amount / order.average
+                        
+                    } else {
+                        tradingEngineOrder.orderStatistics.actualRate.value = order.average
+                        
+                    } 
+                }
+            }  else {tradingEngineOrder.orderStatistics.actualRate.value = order.average}
+
+
+
         } else if (order.price !== undefined) {
             /*
             We use the order.price when the average is not available.
             */
-            tradingEngineOrder.orderStatistics.actualRate.value = order.price
+            // ORIGINAL tradingEngineOrder.orderStatistics.actualRate.value = order.price
+
+
+            if (exchangeConfig.options !== undefined) {
+                if (exchangeConfig.options.defaultType !== undefined) {
+                    defaultType = exchangeConfig.options.defaultType
+    
+                    if (defaultType == 'inverse') {
+                        tradingEngineOrder.orderStatistics.actualRate.value = order.amount / order.price
+                        // console.log ('ORDER AMOUNT/AVERAGE CALCS: ' + tradingEngineOrder.orderBaseAsset.actualSize.value)
+                    } else {
+                        tradingEngineOrder.orderStatistics.actualRate.value = order.price
+                        // console.log ('STD CALCS: ' + tradingEngineOrder.orderBaseAsset.actualSize.value)
+                    } 
+                }
+            }  else {tradingEngineOrder.orderStatistics.actualRate.value = order.price}
+
+
         }
 
         tradingEngineOrder.orderStatistics.actualRate.value = TS.projects.foundations.utilities.miscellaneousFunctions.truncateToThisPrecision(tradingEngineOrder.orderStatistics.actualRate.value, 10)


### PR DESCRIPTION
This PR involves 3 files:

1) HistoricOHLCVs.js -> sandBox + many more parameters we can now use when connecting to exchanges. Now we can use "options" as expected (it was not correctly implemented) and set limit, rateLimit ecc whitout the needing of using "API" that was supposed to be used for fetching candles in an alternative way.

2) ExchangeAPI.js -> sandBox is now correctly working and also all the above parameters are now included so to match the initial instantiation with the exchange. Inside this file the function createOrder is now able to accept parameters as per ccxt manual.
Added 2 more parameters that can be configured at the exchange node and at position node (ie for reduceOnly for example)

3) OrdersCalculation.js -> Initial changes to the code so now SA can correctly trade and keep track of inverse markets like BTC/USDT:BTC

If PR is accepted I will then document the use of the new parameters at the Exchange and Order nodes 