### PR TITLE
Governance: Liquidity Program broken down to exchanges

### DIFF
--- a/Projects/Governance/Schemas/App-Schema/liquidity-program.json
+++ b/Projects/Governance/Schemas/App-Schema/liquidity-program.json
@@ -33,7 +33,7 @@
         "config": true
     },
     "initialValues": {
-        "config": "{\n\"asset\": \"BTCB\"\n}"    },
+        "config": "{\n\"asset\": \"BTCB\",\n\"exchange\": \"PANCAKE\"\n}"    },
     "attachingRules": {
         "compatibleTypes": "->Liquidity Programs->"
     },

--- a/Projects/Governance/Schemas/Docs-Nodes/L/Liquidity/Liquidity-Program/liquidity-program.json
+++ b/Projects/Governance/Schemas/Docs-Nodes/L/Liquidity/Liquidity-Program/liquidity-program.json
@@ -52,13 +52,13 @@
         },
         {
             "style": "Callout",
-            "text": "Spawn one Liquidity Program Node for each asset you have pooled with the Superalgos Token. Click \"Configure\" and enter the code of the paired asset to the node configuration.",
-            "updated": 1644173239186,
+            "text": "Spawn one Liquidity Program Node for each asset you have pooled with the Superalgos Token. Click \"Configure\" and enter the codes of the paired asset and of the exchange to the node configuration.",
+            "updated": 1648995998419,
             "translations": [
                 {
                     "language": "DE",
-                    "text": "Fügen Sie eine Liquidity Program Node für jedes Asset hinzu, das Sie in einem Liquidity Pool mit dem Superalgos Token halten. Klicken Sie dann auf \"Configure\" und geben Sie das Kürzel des Assets ein, das sich mit dem Superalgos Token im Liquidity Pool befindet.",
-                    "updated": 1644743545534
+                    "text": "Fügen Sie eine separate Liquidity Program Node für jedes Asset hinzu, das Sie in einem Liquidity Pool mit dem Superalgos Token halten. Klicken Sie dann auf \"Configure\" und geben Sie das Kürzel des Assets und der Börse ein.",
+                    "updated": 1648996824032
                 },
                 {
                     "language": "RU",
@@ -68,19 +68,68 @@
             ]
         },
         {
-            "style": "Note",
-            "text": "If you hold the same liquidity pool on multiple supported exchanges, do not add additional nodes per exchange. The balances of all supported exchanges are automatically summarized under the asset.",
-            "updated": 1644173429132,
+            "style": "Text",
+            "text": "Example:",
+            "updated": 1648996059714,
             "translations": [
                 {
                     "language": "DE",
-                    "text": "Wenn Sie denselben Liquidity Pool auf mehreren unterstützten Börsen halten, fügen Sie keine zusätzlichen Liquidity Program Nodes je Börse hinzu. Guthaben aller unterstützten Börsen werden automatisch unter dem Asset aufsummiert.",
-                    "updated": 1644743657782
+                    "text": "Beispiel:",
+                    "updated": 1648996735804
                 },
                 {
                     "language": "RU",
                     "text": "Если вы держите один и тот же пул ликвидности на нескольких поддерживаемых биржах, не добавляйте дополнительные узлы на каждую биржу. Остатки на всех поддерживаемых биржах автоматически суммируются под активом.",
                     "updated": 1645181318536
+                }
+            ]
+        },
+        {
+            "style": "Json",
+            "text": "{\n    \"asset\": \"BNB\",\n    \"exchange\": \"BISWAP\"\n}",
+            "updated": 1648996272204
+        },
+        {
+            "style": "Text",
+            "text": "Valid parameter values:",
+            "updated": 1648995488220,
+            "translations": [
+                {
+                    "language": "DE",
+                    "text": "Zulässige Werte:",
+                    "updated": 1648996772301
+                }
+            ]
+        },
+        {
+            "style": "List",
+            "text": "asset: \"BTCB\", \"BNB\", \"BUSD\", \"ETH\""
+        },
+        {
+            "style": "List",
+            "text": "exchange: \"PANCAKE\", \"1INCH\", \"BISWAP\""
+        },
+        {
+            "style": "Success",
+            "text": "If you hold the same liquidity pool on multiple supported exchanges, make sure to add one dedicated node for each combination of asset and exchange.",
+            "updated": 1648995878473,
+            "translations": [
+                {
+                    "language": "DE",
+                    "text": "Falls Sie denselben Liquidity Pool an mehreren unterstützten Börsen halten, legen Sie eine separate Node für jede Kombination aus Asset und Börse an.",
+                    "updated": 1648996921061
+                }
+            ]
+        },
+        {
+            "style": "Note",
+            "text": "When the exchange parameter is missing, the system uses PANCAKE per default.",
+            "updated": 1648995832298,
+            "translations": [
+                {
+                    "language": "DE",
+                    "text": "Sollte der Parameter \"exchange\" fehlen, wird standardmäßig \"PANCAKE\" verwendet.",
+                    "updated": 1648996957182
                 }
             ]
         },

--- a/Projects/Governance/Schemas/Docs-Nodes/L/Liquidity/Liquidity-Programs/liquidity-programs.json
+++ b/Projects/Governance/Schemas/Docs-Nodes/L/Liquidity/Liquidity-Programs/liquidity-programs.json
@@ -145,13 +145,13 @@
         },
         {
             "style": "Text",
-            "text": "For providing liquidity, you are rewarded with tokens from a Liquidity Rewards Pool. There is a decicated Rewards Pool for every asset supported in the Program. The share of reward tokens you receive from the Rewards Pool is proportional to the share you are holding of the Liquidity Pool for the asset.",
-            "updated": 1644171678268,
+            "text": "For providing liquidity, you are rewarded with tokens from a Liquidity Rewards Pool. There is a decicated Rewards Pool for every combination of asset and exchange supported in the Program. The share of reward tokens you receive from the Rewards Pool is proportional to the share you are holding of the Liquidity Pool for the asset.",
+            "updated": 1648994786586,
             "translations": [
                 {
                     "language": "DE",
-                    "text": "Für die Bereitstellung von Liquidität werden Sie mit Tokens aus einem Liquidity Rewards Pool belohnt. Es besteht ein separater Rewards Pool für jedes unterstützte Asset im Liquidity Program. Der Anteil der Token, die Sie aus dem Rewards Pool erhalten, ist proportional zu Ihrem Anteil am Liquidity Pool des jeweiligen Assets.",
-                    "updated": 1644743048952
+                    "text": "Für die Bereitstellung von Liquidität werden Sie mit Tokens aus einem Liquidity Rewards Pool belohnt. Es besteht ein separater Rewards Pool für jede unterstützte Kombination von Asset und Börse im Liquidity Program. Der Anteil der Token, die Sie aus dem Rewards Pool erhalten, ist proportional zu Ihrem Anteil am Liquidity Pool des jeweiligen Assets.",
+                    "updated": 1648996491183
                 },
                 {
                     "language": "RU",
@@ -162,13 +162,13 @@
         },
         {
             "style": "Callout",
-            "text": "Click \"Add Liquidity Program\" and spawn one Liquidity Program node for each asset (BTCB, BNB...) you have pooled at supported exchanges.",
-            "updated": 1644174022853,
+            "text": "Click \"Add Liquidity Program\" and spawn one Liquidity Program node for each asset (BTCB, BNB...) you have pooled at supported exchanges. If you hold the same asset at multiple exchanges, spawn one node for each asset/exchange combination.",
+            "updated": 1648994890471,
             "translations": [
                 {
                     "language": "DE",
-                    "text": "Klicken Sie auf \"Add Liquidity Program\" und fügen Sie eine Liquidity Program Node für jedes Asset hinzu (BTCB, BNB...), über das Sie auf einer unterstützten Börse Liquidität für das Superalgos Token bereitstellen.",
-                    "updated": 1644742988988
+                    "text": "Klicken Sie auf \"Add Liquidity Program\" und fügen Sie eine Liquidity Program Node für jedes Asset hinzu (BTCB, BNB...), über das Sie auf einer unterstützten Börse Liquidität für das Superalgos Token bereitstellen. Falls Sie dasselbe Asset auf mehreren Börsen halten, legen Sie auch für jede Börse eine separate Node an.",
+                    "updated": 1648996624630
                 },
                 {
                     "language": "RU",

--- a/Projects/Governance/UI/Function-Libraries/DistributionProcess.js
+++ b/Projects/Governance/UI/Function-Libraries/DistributionProcess.js
@@ -110,8 +110,25 @@ function newGovernanceFunctionLibraryDistributionProcess() {
             userProfiles
         )
         /*
-        Run the Liquidity Program: One per SA Token Market
+        Run the Liquidity Program: One per SA Token Market and Exchange if contract address defined in SaToken.js
         */
+       const liqAssets = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_LIQUIDITY_ASSETS
+       const liqExchanges = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_EXCHANGES
+       for (let liqAsset of liqAssets) {
+           for (let liqExchange of liqExchanges) {
+               let contractIdentifier = 'UI.projects.governance.globals.saToken.SA_TOKEN_BSC_' + liqExchange + '_LIQUIDITY_POOL_' + liqAsset + '_CONTRACT_ADDRESS'
+               let marketContract = eval(contractIdentifier)
+               if (marketContract !== undefined) {
+                   UI.projects.governance.functionLibraries.liquidityProgram.calculate(
+                       pools,
+                       userProfiles,
+                       liqAsset,
+                       liqExchange
+                    )                    
+               }
+            }
+       }
+       /*
         UI.projects.governance.functionLibraries.liquidityProgram.calculate(
             pools,
             userProfiles,
@@ -132,6 +149,8 @@ function newGovernanceFunctionLibraryDistributionProcess() {
             userProfiles,
             'ETH'
         )
+        */
+
         /*
         Run the Claims Program
         */

--- a/Projects/Governance/UI/Function-Libraries/LiquidityProgram.js
+++ b/Projects/Governance/UI/Function-Libraries/LiquidityProgram.js
@@ -8,7 +8,8 @@ function newGovernanceFunctionLibraryLiquidityProgram() {
     function calculate(
         pools,
         userProfiles,
-        asset
+        asset,
+        exchange
     ) {
         let programPoolTokenReward
         /*
@@ -18,10 +19,22 @@ function newGovernanceFunctionLibraryLiquidityProgram() {
          */
         let accumulatedProgramPower = 0
 
+        if (exchange === undefined) { exchange = "PANCAKE" }
+        let configPropertyObject = {
+            "asset": asset,
+            "exchange": exchange
+        }
+        /* For backwards compatibility, treat empty exchange configurations as PANCAKE */
+        let configFallbackObject = {
+            "asset": asset,
+            "exchange": null
+        }
+        let assetExchange = asset + "-" + exchange
+
         /* Scan Pools Until finding the Pool for this program*/
         for (let i = 0; i < pools.length; i++) {
             let poolsNode = pools[i]
-            programPoolTokenReward = UI.projects.governance.utilities.pools.findPool(poolsNode, "Liquidity-Rewards-" + asset)
+            programPoolTokenReward = UI.projects.governance.utilities.pools.findPool(poolsNode, "Liquidity-Rewards-" + assetExchange)
             if (programPoolTokenReward !== undefined) { break }
         }
         if (programPoolTokenReward === undefined || programPoolTokenReward === 0) { return }
@@ -30,7 +43,13 @@ function newGovernanceFunctionLibraryLiquidityProgram() {
             let userProfile = userProfiles[i]
 
             if (userProfile.tokenPowerSwitch === undefined) { continue }
-            let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
+            //let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
+            let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
+            /* If no result is found, take undefined exchanges as PANCAKE for backwards compatibility */
+            if (program === undefined && exchange === "PANCAKE")
+            {
+                program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configFallbackObject) 
+            }
             if (program === undefined) { continue }
             if (program.payload === undefined) { continue }
 
@@ -40,7 +59,12 @@ function newGovernanceFunctionLibraryLiquidityProgram() {
             let userProfile = userProfiles[i]
 
             if (userProfile.tokenPowerSwitch === undefined) { continue }
-            let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
+            //let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
+            let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
+            if (program === undefined && exchange === "PANCAKE")
+            {
+                program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configFallbackObject) 
+            }
             if (program === undefined) { continue }
             if (program.payload === undefined) { continue }
 
@@ -50,7 +74,12 @@ function newGovernanceFunctionLibraryLiquidityProgram() {
             let userProfile = userProfiles[i]
 
             if (userProfile.tokenPowerSwitch === undefined) { continue }
-            let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
+            //let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
+            let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
+            if (program === undefined && exchange === "PANCAKE")
+            {
+                program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configFallbackObject) 
+            }
             if (program === undefined) { continue }
             if (program.payload === undefined) { continue }
             if (program.payload.liquidityProgram.isActive === false) { continue }
@@ -61,7 +90,12 @@ function newGovernanceFunctionLibraryLiquidityProgram() {
             let userProfile = userProfiles[i]
 
             if (userProfile.tokenPowerSwitch === undefined) { continue }
-            let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
+            //let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
+            let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
+            if (program === undefined && exchange === "PANCAKE")
+            {
+                program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configFallbackObject) 
+            }
             if (program === undefined) { continue }
             if (program.payload === undefined) { continue }
             if (program.payload.liquidityProgram.isActive === false) { continue }
@@ -124,7 +158,7 @@ function newGovernanceFunctionLibraryLiquidityProgram() {
             Here we will convert Liquidity Tokens into Liquidity Power. 
             As per system rules Liquidity Power = userProfile.payload.liquidityTokens
             */
-            let programPower = userProfile.payload.liquidityTokens[asset]
+            let programPower = userProfile.payload.liquidityTokens[assetExchange]
             programNode.payload.liquidityProgram.ownPower = programPower
 
             accumulatedProgramPower = accumulatedProgramPower + programPower

--- a/Projects/Governance/UI/Function-Libraries/TokenMining.js
+++ b/Projects/Governance/UI/Function-Libraries/TokenMining.js
@@ -113,16 +113,32 @@ function newGovernanceFunctionLibraryTokenMining() {
 
             calculateProgram(userProfile, program, "airdropProgram")
         }
+        /* Liquidity Program - Iterate per available asset-exchange-combination */
+        const liqAssets = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_LIQUIDITY_ASSETS
+        const liqExchanges = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_EXCHANGES
         for (let i = 0; i < userProfiles.length; i++) {
             let userProfile = userProfiles[i]
-            for (let j = 0; j < UI.projects.governance.globals.saToken.SA_TOKEN_BSC_LIQUIDITY_ASSETS.length; j++) {
-                let asset = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_LIQUIDITY_ASSETS[j]
-                if (userProfile.tokenPowerSwitch === undefined) { continue }
-                let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
-                if (program === undefined) { continue }
-                if (program.payload === undefined) { continue }
-
-                calculateProgram(userProfile, program, "liquidityProgram")
+            if (userProfile.tokenPowerSwitch === undefined) { continue }
+            for (let liqAsset of liqAssets) {
+                for (let liqExchange of liqExchanges) {
+                    let contractIdentifier = 'UI.projects.governance.globals.saToken.SA_TOKEN_BSC_' + liqExchange + '_LIQUIDITY_POOL_' + liqAsset + '_CONTRACT_ADDRESS'
+                    let marketContract = eval(contractIdentifier)
+                    if (marketContract !== undefined) {
+                        let configPropertyObject = {
+                            "asset": liqAsset,
+                            "exchange": liqExchange
+                        }
+                        let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
+                        /* If nothing found, interpret empty as PANCAKE for backwards compatibility */
+                        if (program === undefined && liqExchange === "PANCAKE") {
+                            configPropertyObject["exchange"] = null
+                            program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject) 
+                        }
+                        if (program === undefined) { continue }
+                        if (program.payload === undefined) { continue }
+                        calculateProgram(userProfile, program, "liquidityProgram")
+                    }
+                } 
             }
         }
 

--- a/Projects/Governance/UI/Spaces/Reports-Space/Liquidity.js
+++ b/Projects/Governance/UI/Spaces/Reports-Space/Liquidity.js
@@ -52,6 +52,13 @@ function newGovernanceReportsLiquidity() {
                     "textAlign": "center"
                 },
                 {
+                    "name": "exchange",
+                    "label": "Exchange",
+                    "type": "string",
+                    "order": "ascending",
+                    "textAlign": "center"
+                },                
+                {
                     "name": "liquidityPower",
                     "label": "Liquidity Power",
                     "type": "number",
@@ -84,27 +91,44 @@ function newGovernanceReportsLiquidity() {
         /*
         Transform the result array into table records.
         */
+        const liqAssets = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_LIQUIDITY_ASSETS
+        const liqExchanges = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_EXCHANGES
 
         for (let j = 0; j < userProfiles.length; j++) {
             let userProfile = userProfiles[j]
-            for (let j = 0; j < UI.projects.governance.globals.saToken.SA_TOKEN_BSC_LIQUIDITY_ASSETS.length; j++) {
-                let asset = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_LIQUIDITY_ASSETS[j]
-                if (userProfile.tokenPowerSwitch === undefined) { continue }
-                let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, programName, 'asset', asset)
-                if (program === undefined) { continue }
-                if (program.payload === undefined) { continue }
-                if (program.payload[programPropertyName] === undefined) { continue }
-
-                let tableRecord = {
-                    "name": userProfile.name,
-                    "market": 'SA / ' + asset,
-                    "liquidityPower": program.payload[programPropertyName].ownPower,
-                    "percentage": program.payload[programPropertyName].awarded.percentage / 100,
-                    "tokensAwarded": program.payload[programPropertyName].awarded.tokens | 0
-                }
-
-                if (UI.projects.governance.utilities.filters.applyFilters(filters, filtersObject, tableRecord) === true) {
-                    tableRecords.push(tableRecord)
+            if (userProfile.tokenPowerSwitch === undefined) { continue }
+            for (let liqAsset of liqAssets) {
+                for (let liqExchange of liqExchanges) {
+                    let contractIdentifier = 'UI.projects.governance.globals.saToken.SA_TOKEN_BSC_' + liqExchange + '_LIQUIDITY_POOL_' + liqAsset + '_CONTRACT_ADDRESS'
+                    let marketContract = eval(contractIdentifier)
+                    if (marketContract !== undefined) {
+                        let configPropertyObject = {
+                            "asset": liqAsset,
+                            "exchange": liqExchange
+                        }
+                        let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
+                        /* If nothing found, interpret empty as PANCAKE for backwards compatibility */
+                        if (program === undefined && liqExchange === "PANCAKE") {
+                            configPropertyObject["exchange"] = null
+                            program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject) 
+                        }
+                        if (program === undefined) { continue }
+                        if (program.payload === undefined) { continue }
+                        if (program.payload[programPropertyName] === undefined) { continue }
+        
+                        let tableRecord = {
+                            "name": userProfile.name,
+                            "market": 'SA / ' + liqAsset,
+                            "exchange": liqExchange,
+                            "liquidityPower": program.payload[programPropertyName].ownPower,
+                            "percentage": program.payload[programPropertyName].awarded.percentage / 100,
+                            "tokensAwarded": program.payload[programPropertyName].awarded.tokens | 0
+                        }
+        
+                        if (UI.projects.governance.utilities.filters.applyFilters(filters, filtersObject, tableRecord) === true) {
+                            tableRecords.push(tableRecord)
+                        }                    
+                    }
                 }
             }
         }

--- a/Projects/Governance/UI/Spaces/User-Profile-Space/UserProfile.js
+++ b/Projects/Governance/UI/Spaces/User-Profile-Space/UserProfile.js
@@ -445,15 +445,30 @@ function newGovernanceUserProfileSpace() {
                     userProfile.payload.blockchainTokens === undefined
                 ) {
                     /* Obtain balance for each asset/liquidity pool configured in SaToken.js */
-                    let assetList = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_LIQUIDITY_ASSETS
+                    const liqAssets = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_LIQUIDITY_ASSETS
+                    const liqExchanges = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_EXCHANGES
                     let initValues = {}
-                    for (let tokenId of assetList) {
-                        initValues[tokenId] = 0
-                    }
+                    for (let liqAsset of liqAssets) {
+                        for (let liqExchange of liqExchanges) {
+                            let contractIdentifier = 'UI.projects.governance.globals.saToken.SA_TOKEN_BSC_' + liqExchange + '_LIQUIDITY_POOL_' + liqAsset + '_CONTRACT_ADDRESS'
+                            let marketContract = eval(contractIdentifier)
+                            if (marketContract !== undefined) {
+                                let assetExchange = liqAsset + "-" + liqExchange
+                                initValues[assetExchange] = 0
+                            }
+                        }
+                    } 
                     userProfile.payload.liquidityTokens = initValues
-                    for (let tokenId of assetList) {
-                        getLiquidityTokenBalance(userProfile, blockchainAccount, tokenId)
-                    }
+
+                    for (let liqAsset of liqAssets) {
+                        for (let liqExchange of liqExchanges) {
+                            let contractIdentifier = 'UI.projects.governance.globals.saToken.SA_TOKEN_BSC_' + liqExchange + '_LIQUIDITY_POOL_' + liqAsset + '_CONTRACT_ADDRESS'
+                            let marketContract = eval(contractIdentifier)
+                            if (marketContract !== undefined) {
+                                getLiquidityTokenBalance(userProfile, blockchainAccount, liqAsset, liqExchange, marketContract)
+                            }
+                        }
+                    } 
 
                     /* 
                     Now we get the SA Tokens Balance.
@@ -501,61 +516,37 @@ function newGovernanceUserProfileSpace() {
         }
 
 
-        function getLiquidityTokenBalance(userProfile, blockchainAccount, asset) {
-            const exchanges = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_EXCHANGES
-            let tokenTotal = 0
-            
-            /* Obtain contract addresses for configured liquidity pools */
-            let contracts = {}
-            for (let i = 0; i < exchanges.length; i++) {
-                let contractIdentifier = 'UI.projects.governance.globals.saToken.SA_TOKEN_BSC_' + exchanges[i] + '_LIQUIDITY_POOL_' + asset + '_CONTRACT_ADDRESS'
-                let marketContract = ''
-                marketContract = eval(contractIdentifier)
-                if (marketContract !== undefined) {
-                    contracts[exchanges[i]] = marketContract
+        function getLiquidityTokenBalance(userProfile, blockchainAccount, asset, exchange, marketContract) {
+            let assetExchange = asset + "-" + exchange
+            let request = {
+                url: 'WEB3',
+                params: {
+                    method: "getUserWalletBalance",
+                    walletAddress: blockchainAccount,
+                    contractAddress: marketContract
                 }
             }
-            
-            let neededResponses = Object.keys(contracts).length
-            for (let dex in contracts) {
-                //console.log((new Date()).toISOString(), '[INFO] Loading ' + dex + ' Balance for User Profile: ' + userProfile.name + ' blockchainAccount: ' + blockchainAccount + ' asset: ' + asset)
-                let request = {
-                    url: 'WEB3',
-                    params: {
-                        method: "getUserWalletBalance",
-                        walletAddress: blockchainAccount,
-                        contractAddress: contracts[dex]
+
+            httpRequest(JSON.stringify(request.params), request.url, onResponse)           
+        
+            function onResponse(err, data) {
+                if (err.result === GLOBAL.DEFAULT_FAIL_RESPONSE) {
+                    console.log((new Date()).toISOString(), '[WARN] Error fetching ' + exchange + ' liquidity tokens for asset ' + asset + ' of user profile ' + userProfile.name)
+                    userProfile.payload.blockchainTokens = undefined
+                } else {
+                    let commandResponse = JSON.parse(data)
+                    if (commandResponse.result !== "Ok") {
+                        console.log((new Date()).toISOString(), '[WARN] Web3 Error fetching ' + exchange + ' liquidity tokens for asset ' + asset + ' of user profile ' + userProfile.name)
+                        return
                     }
+                    console.log((new Date()).toISOString(), '[INFO]', exchange ,'Liquidity of', userProfile.name, 'for asset', asset, 'is ', Number(commandResponse.balance))
+                    userProfile.payload.liquidityTokens[assetExchange] = Number(commandResponse.balance)
+                    userProfile.payload.uiObject.setInfoMessage('Balance Successfully Loaded for asset ' + asset,
+                        UI.projects.governance.globals.designer.SET_INFO_COUNTER_FACTOR
+                    )
                 }
-
-                httpRequest(JSON.stringify(request.params), request.url, onResponse)           
-            
-                function onResponse(err, data) {
-                    --neededResponses
-                    if (err.result === GLOBAL.DEFAULT_FAIL_RESPONSE) {
-                        console.log((new Date()).toISOString(), '[WARN] Error fetching ' + dex + ' liquidity tokens for asset ' + asset + ' of user profile ' + userProfile.name)
-                        userProfile.payload.blockchainTokens = undefined
-                    } else {
-                        let commandResponse = JSON.parse(data)
-                        if (commandResponse.result !== "Ok") {
-                            console.log((new Date()).toISOString(), '[WARN] Web3 Error fetching ' + dex + ' liquidity tokens for asset ' + asset + ' of user profile ' + userProfile.name)
-                            return
-                        }
-
-                        tokenTotal = tokenTotal + Number(commandResponse.balance)
-                        console.log((new Date()).toISOString(), '[INFO]', dex ,'Liquidity of', userProfile.name, 'for asset', asset, 'is ', Number(commandResponse.balance))
-                        if (neededResponses === 0) {
-                            userProfile.payload.liquidityTokens[asset] = tokenTotal
-                            console.log((new Date()).toISOString(), '[INFO] TOTAL Liquidity of', userProfile.name, 'for asset', asset, 'is ', userProfile.payload.liquidityTokens[asset])
-                            userProfile.payload.uiObject.setInfoMessage('Balance Successfully Loaded for asset ' + asset,
-                                UI.projects.governance.globals.designer.SET_INFO_COUNTER_FACTOR
-                            )
-                        }
-                    }
-                }            
-            }            
+            }                         
         }
-
     }
 
     function draw() {

--- a/Projects/Governance/UI/Utilities/Validations.js
+++ b/Projects/Governance/UI/Utilities/Validations.js
@@ -1,7 +1,8 @@
 function newGovernanceUtilitiesValidations() {
     let thisObject = {
         onlyOneProgram: onlyOneProgram,
-        onlyOneProgramBasedOnConfigProperty: onlyOneProgramBasedOnConfigProperty
+        onlyOneProgramBasedOnConfigProperty: onlyOneProgramBasedOnConfigProperty,
+        onlyOneProgramBasedOnMultipleConfigProperties: onlyOneProgramBasedOnMultipleConfigProperties
     }
 
     return thisObject
@@ -35,6 +36,30 @@ function newGovernanceUtilitiesValidations() {
                 let program = programs[i]
                 let propertyValue = UI.projects.visualScripting.utilities.nodeConfig.loadConfigProperty(program.payload, configProperetyName)
                 if (propertyValue === configProperetyValue) {
+                    return program
+                }
+            }
+        }
+    }
+
+    function onlyOneProgramBasedOnMultipleConfigProperties(userProfile, programNodeType, configPropertyObject) {
+        /*
+         Find all the nodes representing the current program. All parameters passed in the configPropertyObject must be configured.
+         */
+        let programs = UI.projects.visualScripting.utilities.branches.nodeBranchToArray(userProfile, programNodeType)
+        if (programs !== undefined) {
+            for (let i = 0; i < programs.length; i++) {
+                let program = programs[i]
+                let valid = true
+                for (let configPropertyName in configPropertyObject) {
+                    let configPropertyValue = configPropertyObject[configPropertyName]
+                    let propertyValue = UI.projects.visualScripting.utilities.nodeConfig.loadConfigProperty(program.payload, configPropertyName)
+                    if ((propertyValue === undefined || propertyValue === '') && configPropertyValue === null) { continue }
+                    if (propertyValue !== configPropertyValue) { 
+                        valid = false
+                    }
+                }
+                if (valid === true) {
                     return program
                 }
             }


### PR DESCRIPTION
Until now, we have summarized liquidity on asset basis to determine the share of rewards from one central asset pool (e.g. all SA/BTC liquidity across several exchanges were rewarded from one BTC liquidity program pool).

With this change, as suggested by Luis, we are breaking the reward logic down further to separate pools per combination of asset and exchange (i.e. we will have a SA/BTC-Pool for Pancakeswap and a separate one for 1inch). This will allow more granular steering and future scalability.