### PR TITLE
Governance: Bitcoin Factory Rewards update

### DIFF
--- a/Platform/Client/bitcoinFactoryServer.js
+++ b/Platform/Client/bitcoinFactoryServer.js
@@ -225,6 +225,9 @@ exports.newBitcoinFactoryServer = function newBitcoinFactoryServer() {
         let rewardsFile = ""
         let reportsDirectory = []
         const testsPerUser = {}
+        let recordsCounter = 0
+        /* Debug Mode provides more verbose output about each processed Rewards File on the Console */
+        const debugMode = false
         try {
             reportsDirectory = SA.nodeModules.fs.readdirSync('./Bitcoin-Factory/Reports')
         }
@@ -238,7 +241,8 @@ exports.newBitcoinFactoryServer = function newBitcoinFactoryServer() {
         for (let f = 0; f < reportsDirectory.length; f++) {
             /* Check if file name matches pattern Testnet*.csv for processing Test Client rewards */
             rewardsFile = ""
-            if (/^Testnet[\w|-]*\.csv$/.test(reportsDirectory[f]) === false) { 
+            recordsCounter = 0
+            if (/^Testnet[\w\s-]*\.csv$/gi.test(reportsDirectory[f]) === false) { 
                 continue
             } else {
                 try {
@@ -300,9 +304,20 @@ exports.newBitcoinFactoryServer = function newBitcoinFactoryServer() {
                         } else {
                             testsPerUser[profile] = 1
                         }
+                        recordsCounter++
+                    }
+                }
+                if (debugMode === true) {
+                    if (recordsCounter === 0) {
+                        console.log((new Date()).toISOString(), "[INFO] Governance Rewards File", reportsDirectory[f], "does not contain any records for this period")
+                    } else {
+                        console.log((new Date()).toISOString(), "[INFO] Governance Rewards File", reportsDirectory[f], "contains", recordsCounter, "valid records")
                     }
                 }
             }
+        }
+        if (debugMode === true) {
+            console.log((new Date()).toISOString(), "[INFO] Total executed Bitcoin Factory Test Cases per User:", testsPerUser)
         }
         return {
             result: 'Ok',

--- a/Projects/Governance/UI/Spaces/User-Profile-Space/UserProfile.js
+++ b/Projects/Governance/UI/Spaces/User-Profile-Space/UserProfile.js
@@ -383,8 +383,6 @@ function newGovernanceUserProfileSpace() {
         fomTimestamp = fom.getTime()
         eomTimestamp = eom.getTime()
 
-        /* Special handling for first distribution: Set from timestamp to 0. Delete this line for distros later than May 22, executed in June 22 */
-        fomTimestamp = 0
         return [fomTimestamp, eomTimestamp]
     }
 


### PR DESCRIPTION
Removed special rule for the first month of rewards which counted test cases regardless how far back in time they were done. Now only counting test cases conducted during the preceding calendar month to avoid double rewards.

Some stability + debugging improvements.