### PR TITLE
Fixed Typo In Building Time Series File

### DIFF
--- a/Projects/Data-Mining/TS/Bot-Modules/Indicator-Bot/FromOneMinToMultiTimeFrameMarket.js
+++ b/Projects/Data-Mining/TS/Bot-Modules/Indicator-Bot/FromOneMinToMultiTimeFrameMarket.js
@@ -410,8 +410,8 @@ exports.newDataMiningBotModulesFromOneMinToMultiTimeFrameMarket = function (proc
 
             /* Check Time Frames Filter */
             if (TS.projects.foundations.globals.taskConstants.TASK_NODE.bot.timeFramesFilter !== undefined) {
-                if (TS.projects.foundations.globals.taskConstants.TASK_NODE.bot.timeFramesFilter.config.dailyTimeFrames !== undefined) {
-                    if (TS.projects.foundations.globals.taskConstants.TASK_NODE.bot.timeFramesFilter.config.dailyTimeFrames.includes(timeFrameLabel) === true) {
+                if (TS.projects.foundations.globals.taskConstants.TASK_NODE.bot.timeFramesFilter.config.marketTimeFrames !== undefined) {
+                    if (TS.projects.foundations.globals.taskConstants.TASK_NODE.bot.timeFramesFilter.config.marketTimeFrames.includes(timeFrameLabel) === true) {
                         timeFramesArray.push(timeFrameLabel)
                     }
                 } else {


### PR DESCRIPTION
Fixed typo creating a problem with building the time series file for the "From-One-Min-To-Multi-Time-Frame-Market".