### PR TITLE
Governance: Consolidation of Liquidity Rewards Pools into one

### DIFF
--- a/Platform/Client/httpInterface.js
+++ b/Platform/Client/httpInterface.js
@@ -172,6 +172,17 @@ exports.newHttpInterface = function newHttpInterface() {
                                     SA.projects.foundations.utilities.httpResponses.respondWithContent(JSON.stringify(serverResponse), httpResponse)
                                     return
                                 }
+                                case 'getLPTokenBalance': {
+
+                                    let serverResponse = await PL.servers.WEB3_SERVER.getLPTokenBalance(
+                                        params.chain,
+                                        params.contractAddressSA,
+                                        params.contractAddressLP
+                                    )
+
+                                    SA.projects.foundations.utilities.httpResponses.respondWithContent(JSON.stringify(serverResponse), httpResponse)
+                                    return
+                                }
                                 case 'getWalletBalances': {
 
                                     let serverResponse = await PL.servers.WEB3_SERVER.getWalletBalances(

--- a/Platform/Client/web3Server.js
+++ b/Platform/Client/web3Server.js
@@ -6,6 +6,7 @@ exports.newWeb3Server = function newWeb3Server() {
         getNetworkClientStatus: getNetworkClientStatus,
         createWalletAccount: createWalletAccount,
         getUserWalletBalance: getUserWalletBalance,
+        getLPTokenBalance: getLPTokenBalance,
         getWalletBalances: getWalletBalances,
         signData: signData,
         hashData: hashData,
@@ -109,6 +110,48 @@ exports.newWeb3Server = function newWeb3Server() {
         }
     }
 
+    async function getLPTokenBalance(chain, contractAddressSA, contractAddressLP) {
+        let tokensLP
+        let tokensSA
+        let URI = ''
+        let ABI = ''
+        switch (chain) {
+            case 'BSC':
+                URI = 'https://bscrpc.com'
+                ABI = [{ "constant": true, "inputs": [], "name": "name", "outputs": [{ "name": "", "type": "string" }], "payable": false, "stateMutability": "view", "type": "function" }, { "constant": false, "inputs": [{ "name": "_spender", "type": "address" }, { "name": "_value", "type": "uint256" }], "name": "approve", "outputs": [{ "name": "", "type": "bool" }], "payable": false, "stateMutability": "nonpayable", "type": "function" }, { "constant": true, "inputs": [], "name": "totalSupply", "outputs": [{ "name": "", "type": "uint256" }], "payable": false, "stateMutability": "view", "type": "function" }, { "constant": false, "inputs": [{ "name": "_from", "type": "address" }, { "name": "_to", "type": "address" }, { "name": "_value", "type": "uint256" }], "name": "transferFrom", "outputs": [{ "name": "", "type": "bool" }], "payable": false, "stateMutability": "nonpayable", "type": "function" }, { "constant": true, "inputs": [], "name": "decimals", "outputs": [{ "name": "", "type": "uint256" }], "payable": false, "stateMutability": "view", "type": "function" }, { "constant": false, "inputs": [], "name": "unpause", "outputs": [], "payable": false, "stateMutability": "nonpayable", "type": "function" }, { "constant": false, "inputs": [{ "name": "account", "type": "address" }, { "name": "amount", "type": "uint256" }], "name": "mint", "outputs": [], "payable": false, "stateMutability": "nonpayable", "type": "function" }, { "constant": false, "inputs": [{ "name": "_value", "type": "uint256" }], "name": "burn", "outputs": [], "payable": false, "stateMutability": "nonpayable", "type": "function" }, { "constant": true, "inputs": [], "name": "paused", "outputs": [{ "name": "", "type": "bool" }], "payable": false, "stateMutability": "view", "type": "function" }, { "constant": false, "inputs": [{ "name": "_spender", "type": "address" }, { "name": "_subtractedValue", "type": "uint256" }], "name": "decreaseApproval", "outputs": [{ "name": "success", "type": "bool" }], "payable": false, "stateMutability": "nonpayable", "type": "function" }, { "constant": true, "inputs": [{ "name": "_owner", "type": "address" }], "name": "balanceOf", "outputs": [{ "name": "balance", "type": "uint256" }], "payable": false, "stateMutability": "view", "type": "function" }, { "constant": false, "inputs": [{ "name": "listAddress", "type": "address" }, { "name": "isBlackListed", "type": "bool" }], "name": "blackListAddress", "outputs": [{ "name": "success", "type": "bool" }], "payable": false, "stateMutability": "nonpayable", "type": "function" }, { "constant": false, "inputs": [], "name": "pause", "outputs": [], "payable": false, "stateMutability": "nonpayable", "type": "function" }, { "constant": true, "inputs": [], "name": "owner", "outputs": [{ "name": "", "type": "address" }], "payable": false, "stateMutability": "view", "type": "function" }, { "constant": true, "inputs": [], "name": "symbol", "outputs": [{ "name": "", "type": "string" }], "payable": false, "stateMutability": "view", "type": "function" }, { "constant": false, "inputs": [{ "name": "_to", "type": "address" }, { "name": "_value", "type": "uint256" }], "name": "transfer", "outputs": [{ "name": "", "type": "bool" }], "payable": false, "stateMutability": "nonpayable", "type": "function" }, { "constant": false, "inputs": [{ "name": "_spender", "type": "address" }, { "name": "_addedValue", "type": "uint256" }], "name": "increaseApproval", "outputs": [{ "name": "success", "type": "bool" }], "payable": false, "stateMutability": "nonpayable", "type": "function" }, { "constant": true, "inputs": [{ "name": "_owner", "type": "address" }, { "name": "_spender", "type": "address" }], "name": "allowance", "outputs": [{ "name": "", "type": "uint256" }], "payable": false, "stateMutability": "view", "type": "function" }, { "constant": false, "inputs": [{ "name": "newOwner", "type": "address" }], "name": "transferOwnership", "outputs": [], "payable": false, "stateMutability": "nonpayable", "type": "function" }, { "inputs": [{ "name": "_name", "type": "string" }, { "name": "_symbol", "type": "string" }, { "name": "_decimals", "type": "uint256" }, { "name": "_supply", "type": "uint256" }, { "name": "tokenOwner", "type": "address" }], "payable": false, "stateMutability": "nonpayable", "type": "constructor" }, { "anonymous": false, "inputs": [{ "indexed": true, "name": "from", "type": "address" }, { "indexed": true, "name": "to", "type": "address" }, { "indexed": false, "name": "value", "type": "uint256" }], "name": "Mint", "type": "event" }, { "anonymous": false, "inputs": [{ "indexed": true, "name": "burner", "type": "address" }, { "indexed": false, "name": "value", "type": "uint256" }], "name": "Burn", "type": "event" }, { "anonymous": false, "inputs": [], "name": "Pause", "type": "event" }, { "anonymous": false, "inputs": [], "name": "Unpause", "type": "event" }, { "anonymous": false, "inputs": [{ "indexed": true, "name": "previousOwner", "type": "address" }, { "indexed": true, "name": "newOwner", "type": "address" }], "name": "OwnershipTransferred", "type": "event" }, { "anonymous": false, "inputs": [{ "indexed": true, "name": "blackListed", "type": "address" }, { "indexed": false, "name": "value", "type": "bool" }], "name": "Blacklist", "type": "event" }, { "anonymous": false, "inputs": [{ "indexed": true, "name": "owner", "type": "address" }, { "indexed": true, "name": "spender", "type": "address" }, { "indexed": false, "name": "value", "type": "uint256" }], "name": "Approval", "type": "event" }, { "anonymous": false, "inputs": [{ "indexed": true, "name": "from", "type": "address" }, { "indexed": true, "name": "to", "type": "address" }, { "indexed": false, "name": "value", "type": "uint256" }], "name": "Transfer", "type": "event" }]
+                break
+            default:
+                return {
+                    tokensLP: undefined,
+                    tokensSA: undefined,
+                    result: 'Fail'
+                }
+        }
+        
+        const web3 = new Web3(URI)
+        const contractInstLP = new web3.eth.Contract(ABI, contractAddressLP)
+        const contractInstSA = new web3.eth.Contract(ABI, contractAddressSA)
+
+        async function getLPTokenSupply() {
+            tokensLP = await contractInstLP.methods.totalSupply().call().then(result => web3.utils.fromWei(result, 'ether'))
+            return tokensLP
+        }
+
+        async function getSATokenBalance() {
+            tokensSA = await contractInstSA.methods.balanceOf(contractAddressLP).call().then(result => web3.utils.fromWei(result, 'ether'))
+            return tokensSA
+        }
+
+        await getLPTokenSupply()
+        await getSATokenBalance()
+
+        return {
+            tokensLP: tokensLP,
+            tokensSA: tokensSA,
+            result: 'Ok'
+        }
+    }
+     
     async function getWalletBalances(host, port, interface, walletDefinition) {
         let key = 'host (' + host + ') at port (' + port + ') via interface (' + interface + ')'
 

--- a/Projects/Governance/UI/Function-Libraries/ComputingProgram.js
+++ b/Projects/Governance/UI/Function-Libraries/ComputingProgram.js
@@ -12,7 +12,7 @@ function newGovernanceFunctionLibraryComputingProgram() {
         let programPoolTokenReward
         /*
         In order to be able to calculate the share of the Program Pool for each User Profile,
-        we need to accumulate all the Liquidity Power that each User Profile at their Program
+        we need to accumulate all the Program Power that each User Profile at their Program
         node has, because with that Power is that each Program node gets a share of the pool.
          */
         let accumulatedProgramPower = 0
@@ -94,7 +94,7 @@ function newGovernanceFunctionLibraryComputingProgram() {
 
         function validateProgram(node, userProfile) {
             /*
-            This program is not going to run unless the Profile has Liquidity Tokens, and for 
+            This program is not going to run unless the Profile has data on executed test cases, and for 
             that users needs to execute the setup procedure of signing their Github
             username with their private key.
             */
@@ -116,8 +116,7 @@ function newGovernanceFunctionLibraryComputingProgram() {
         function distributeProgram(programNode, userProfile) {
             if (programNode === undefined || programNode.payload === undefined) { return }
             /*
-            Here we will convert Liquidity Tokens into Liquidity Power. 
-            As per system rules Liquidity Power = userProfile.payload.liquidityTokens
+            Here we will convert the executed test case count into program power. 
             */
             let programPower = 0
             if (UI.projects.governance.spaces.userProfileSpace.executedTestCases.has(userProfile.name) === true) {

--- a/Projects/Governance/UI/Function-Libraries/DistributionProcess.js
+++ b/Projects/Governance/UI/Function-Libraries/DistributionProcess.js
@@ -119,22 +119,10 @@ function newGovernanceFunctionLibraryDistributionProcess() {
         /*
         Run the Liquidity Program: One per SA Token Market and Exchange if contract address defined in SaToken.js
         */
-       const liqAssets = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_LIQUIDITY_ASSETS
-       const liqExchanges = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_EXCHANGES
-       for (let liqAsset of liqAssets) {
-           for (let liqExchange of liqExchanges) {
-               let contractIdentifier = 'UI.projects.governance.globals.saToken.SA_TOKEN_BSC_' + liqExchange + '_LIQUIDITY_POOL_' + liqAsset + '_CONTRACT_ADDRESS'
-               let marketContract = eval(contractIdentifier)
-               if (marketContract !== undefined) {
-                   UI.projects.governance.functionLibraries.liquidityProgram.calculate(
-                       pools,
-                       userProfiles,
-                       liqAsset,
-                       liqExchange
-                    )                    
-               }
-            }
-       }
+        UI.projects.governance.functionLibraries.liquidityProgram.calculate(
+            pools,
+            userProfiles
+        )                    
         /*
         Run the Claims Program
         */

--- a/Projects/Governance/UI/Function-Libraries/LiquidityProgram.js
+++ b/Projects/Governance/UI/Function-Libraries/LiquidityProgram.js
@@ -3,13 +3,12 @@ function newGovernanceFunctionLibraryLiquidityProgram() {
         calculate: calculate
     }
 
+    let liquidityProgramBalanceList = []
     return thisObject
 
     function calculate(
         pools,
-        userProfiles,
-        asset,
-        exchange
+        userProfiles
     ) {
         let programPoolTokenReward
         /*
@@ -17,90 +16,187 @@ function newGovernanceFunctionLibraryLiquidityProgram() {
         we need to accumulate all the Liquidity Power that each User Profile at their Program
         node has, because with that Power is that each Program node gets a share of the pool.
          */
-        let accumulatedProgramPower = 0
 
-        if (exchange === undefined) { exchange = "PANCAKE" }
-        let configPropertyObject = {
-            "asset": asset,
-            "exchange": exchange
-        }
-        /* For backwards compatibility, treat empty exchange configurations as PANCAKE */
-        let configFallbackObject = {
-            "asset": asset,
-            "exchange": null
-        }
-        let assetExchange = asset + "-" + exchange
+        let accumulatedSATokens = 0
+        let asset = ''
+        let exchange = ''
+        let chain = ''
+        let configPropertyObject = {}
+        let configFallbackObject = {}
+        let assetExchange = ''
+        let loadCompleted = true
 
-        /* Scan Pools Until finding the Pool for this program*/
-        for (let i = 0; i < pools.length; i++) {
-            let poolsNode = pools[i]
-            programPoolTokenReward = UI.projects.governance.utilities.pools.findPool(poolsNode, "Liquidity-Rewards-" + assetExchange)
-            if (programPoolTokenReward !== undefined) { break }
-        }
-        if (programPoolTokenReward === undefined || programPoolTokenReward === 0) { return }
 
-        for (let i = 0; i < userProfiles.length; i++) {
-            let userProfile = userProfiles[i]
+        if (liquidityProgramBalanceList.length === 0) {
+            initializeLiquidityPools()
+        } 
 
-            if (userProfile.tokenPowerSwitch === undefined) { continue }
-            //let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
-            let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
-            /* If no result is found, take undefined exchanges as PANCAKE for backwards compatibility */
-            if (program === undefined && exchange === "PANCAKE")
-            {
-                program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configFallbackObject) 
+        for (let liqProgram of liquidityProgramBalanceList) {
+            asset = liqProgram['pairedAsset']
+            exchange = liqProgram['exchange']
+            chain = liqProgram['chain']
+
+            configPropertyObject = {
+                "asset": asset,
+                "exchange": exchange
             }
-            if (program === undefined) { continue }
-            if (program.payload === undefined) { continue }
-
-            resetProgram(program)
-        }
-        for (let i = 0; i < userProfiles.length; i++) {
-            let userProfile = userProfiles[i]
-
-            if (userProfile.tokenPowerSwitch === undefined) { continue }
-            //let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
-            let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
-            if (program === undefined && exchange === "PANCAKE")
-            {
-                program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configFallbackObject) 
+            /* For backwards compatibility, treat empty exchange configurations as PANCAKE */
+            configFallbackObject = {
+                "asset": asset,
+                "exchange": null
             }
-            if (program === undefined) { continue }
-            if (program.payload === undefined) { continue }
+            assetExchange = asset + "-" + exchange
 
-            validateProgram(program, userProfile)
-        }
-        for (let i = 0; i < userProfiles.length; i++) {
-            let userProfile = userProfiles[i]
-
-            if (userProfile.tokenPowerSwitch === undefined) { continue }
-            //let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
-            let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
-            if (program === undefined && exchange === "PANCAKE")
-            {
-                program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configFallbackObject) 
+            /* Scan Pools Until finding the Pool for this program*/
+            for (let i = 0; i < pools.length; i++) {
+                let poolsNode = pools[i]
+                programPoolTokenReward = UI.projects.governance.utilities.pools.findPool(poolsNode, "Liquidity-Rewards")
+                if (programPoolTokenReward !== undefined) { break }
             }
-            if (program === undefined) { continue }
-            if (program.payload === undefined) { continue }
-            if (program.payload.liquidityProgram.isActive === false) { continue }
+            if (programPoolTokenReward === undefined || programPoolTokenReward === 0) { continue }
 
-            distributeProgram(program, userProfile)
-        }
-        for (let i = 0; i < userProfiles.length; i++) {
-            let userProfile = userProfiles[i]
+            for (let i = 0; i < userProfiles.length; i++) {
+                let userProfile = userProfiles[i]
 
-            if (userProfile.tokenPowerSwitch === undefined) { continue }
-            //let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
-            let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
-            if (program === undefined && exchange === "PANCAKE")
-            {
-                program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configFallbackObject) 
+                if (userProfile.tokenPowerSwitch === undefined) { continue }
+                //let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
+                let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
+                /* If no result is found, take undefined exchanges as PANCAKE for backwards compatibility */
+                if (program === undefined && exchange === "PANCAKE")
+                {
+                    program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configFallbackObject) 
+                }
+                if (program === undefined) { continue }
+                if (program.payload === undefined) { continue }
+
+                resetProgram(program)
             }
-            if (program === undefined) { continue }
-            if (program.payload === undefined) { continue }
-            if (program.payload.liquidityProgram.isActive === false) { continue }
+            for (let i = 0; i < userProfiles.length; i++) {
+                let userProfile = userProfiles[i]
 
-            calculateProgram(program)
+                if (userProfile.tokenPowerSwitch === undefined) { continue }
+                //let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
+                let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
+                if (program === undefined && exchange === "PANCAKE")
+                {
+                    program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configFallbackObject) 
+                }
+                if (program === undefined) { continue }
+                if (program.payload === undefined) { continue }
+
+                validateProgram(program, userProfile)
+            }
+            for (let i = 0; i < userProfiles.length; i++) {
+                let userProfile = userProfiles[i]
+
+                if (userProfile.tokenPowerSwitch === undefined) { continue }
+                //let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
+                let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
+                if (program === undefined && exchange === "PANCAKE")
+                {
+                    program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configFallbackObject) 
+                }
+                if (program === undefined) { continue }
+                if (program.payload === undefined) { continue }
+                if (program.payload.liquidityProgram.isActive === false) { continue }
+                if (loadCompleted === false) {continue}
+
+                distributeProgram(program, userProfile, assetExchange)
+            }
+        }
+
+
+        /* Calculation loop only after accumulation of SA Token balances across all chain-asset-exchange combinations */
+        for (let liqProgram of liquidityProgramBalanceList) {
+            asset = liqProgram['pairedAsset']
+            exchange = liqProgram['exchange']
+
+            configPropertyObject = {
+                "asset": asset,
+                "exchange": exchange
+            }
+            /* For backwards compatibility, treat empty exchange configurations as PANCAKE */
+            configFallbackObject = {
+                "asset": asset,
+                "exchange": null
+            }
+            assetExchange = asset + "-" + exchange
+
+            for (let i = 0; i < pools.length; i++) {
+                let poolsNode = pools[i]
+                programPoolTokenReward = UI.projects.governance.utilities.pools.findPool(poolsNode, "Liquidity-Rewards")
+                if (programPoolTokenReward !== undefined)  { break }
+            }
+            if (programPoolTokenReward === undefined || programPoolTokenReward === 0) { continue }
+
+            for (let i = 0; i < userProfiles.length; i++) {
+                let userProfile = userProfiles[i]
+
+                if (userProfile.tokenPowerSwitch === undefined) { continue }
+                //let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnConfigProperty(userProfile, "Liquidity Program", 'asset', asset)
+                let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
+                if (program === undefined && exchange === "PANCAKE")
+                {
+                    program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configFallbackObject) 
+                }
+                if (program === undefined) { continue }
+                if (program.payload === undefined) { continue }
+                if (program.payload.liquidityProgram.isActive === false) { continue }
+                if (loadCompleted === false) {continue}
+                calculateProgram(program, assetExchange)
+            }
+
+        }
+
+
+        function initializeLiquidityPools() {
+            let liquidityProgramList = UI.projects.governance.globals.saToken.SA_TOKEN_LIQUIDITY_POOL_LIST
+            for (let liqProgram of liquidityProgramList) {
+                let localObject = {}
+                for (let key in liqProgram) {
+                    if (key === "chain" || key === "exchange" || key === "pairedAsset" || key === 'contractAddress') {
+                        localObject[key] = liqProgram[key]
+                    }
+                }
+                localObject.LPTokenBalance = undefined
+                localObject.SATokenBalance = undefined
+                liquidityProgramBalanceList.push(localObject)
+            }
+            getLiquidityPoolBalances()
+        }
+
+        function getLiquidityPoolBalances() {
+            let callCounter = 0
+            for (let liqProgram of liquidityProgramBalanceList) {
+                let contractAddressSA = UI.projects.governance.utilities.chains.getSATokenAddress(liqProgram.chain)
+                let request = {
+                    url: 'WEB3',
+                    params: {
+                        method: 'getLPTokenBalance',
+                        chain: liqProgram.chain,
+                        contractAddressSA: contractAddressSA,
+                        contractAddressLP: liqProgram.contractAddress
+                    }
+                }
+                /* Delaying calls not to hit RPC's max request rate */
+                setTimeout(() => { httpRequest(JSON.stringify(request.params), request.url, onResponse) }, callCounter * 1000)
+    
+                function onResponse(err, data) {
+                    if (err.result === GLOBAL.DEFAULT_FAIL_RESPONSE) {
+                        console.log((new Date()).toISOString(), '[WARN] Error fetching Liquidity Pool information on ', liqProgram.chain , ' exchange ', liqProgram.exchange, ' asset ', liqProgram.pairedAsset)
+                    } else {
+                        let commandResponse = JSON.parse(data)
+                        if (commandResponse.result !== "Ok") {
+                            console.log((new Date()).toISOString(), '[WARN] Error fetching Liquidity Pool information on ', liqProgram.chain , ' exchange ', liqProgram.exchange, ' asset ', liqProgram.pairedAsset)
+                            return
+                        }
+                        liqProgram['LPTokenBalance'] = commandResponse.tokensLP
+                        liqProgram['SATokenBalance'] = commandResponse.tokensSA
+                        console.log((new Date()).toISOString(), '[INFO]', liqProgram.chain, 'Liquidity on', liqProgram.exchange, 'for asset', liqProgram.pairedAsset, 'is ', Number(commandResponse.tokensLP), 'LP Tokens and ', Number(commandResponse.tokensSA), 'SA Tokens')
+                    }
+                }
+            callCounter++
+            }
         }
 
         function resetProgram(node) {
@@ -150,21 +246,45 @@ function newGovernanceFunctionLibraryLiquidityProgram() {
                 userProfile.payload.uiObject.resetErrorMessage()
                 node.payload.liquidityProgram.isActive = true
             }
+            loadCompleted = true
+            for (let liqProgram of liquidityProgramBalanceList) {
+                if (liqProgram['LPTokenBalance'] === undefined || liqProgram['SATokenBalance'] === undefined) {
+                    loadCompleted = false
+                    console.log("LP Balances for", liqProgram['chain'], liqProgram['exchange'], liqProgram['pairedAsset'], "not yet loaded.")
+                    return
+                }
+            }
         }
 
-        function distributeProgram(programNode, userProfile) {
+        function distributeProgram(programNode, userProfile, assetExchange) {
             if (programNode === undefined || programNode.payload === undefined) { return }
             /*
             Here we will convert Liquidity Tokens into Liquidity Power. 
             As per system rules Liquidity Power = userProfile.payload.liquidityTokens
             */
             let programPower = userProfile.payload.liquidityTokens[assetExchange]
-            programNode.payload.liquidityProgram.ownPower = programPower
+            //programNode.payload.liquidityProgram.ownPower = programPower
 
-            accumulatedProgramPower = accumulatedProgramPower + programPower
+            let totalLPTokens = undefined
+            let totalSATokens = undefined
+            let programSATokens = undefined
+            for (let liqProgram of liquidityProgramBalanceList) {
+                if (liqProgram['chain'] === chain && liqProgram['pairedAsset'] === asset && liqProgram['exchange'] === exchange) {
+                    totalLPTokens = liqProgram['LPTokenBalance']
+                    totalSATokens = liqProgram['SATokenBalance']
+                    break
+                }
+            }
+
+            if (totalLPTokens !== undefined && totalSATokens !== undefined && totalLPTokens > 0) {
+                programSATokens = totalSATokens / totalLPTokens * programPower
+                //console.log("Calculated SA Tokens for", userProfile.name, asset, exchange, ":", programSATokens, "Tokens")
+                programNode.payload.liquidityProgram.ownPower = programSATokens
+                accumulatedSATokens = accumulatedSATokens + programSATokens
+            }          
         }
 
-        function calculateProgram(programNode) {
+        function calculateProgram(programNode, assetExchange) {
 
             if (programNode.payload === undefined) { return }
             if (programNode.tokensAwarded === undefined || programNode.tokensAwarded.payload === undefined) {
@@ -179,7 +299,7 @@ function newGovernanceFunctionLibraryLiquidityProgram() {
             To do that, we use the ownPower, to see which proportion of the accumulatedProgramPower
             represents.
             */
-            programNode.payload.liquidityProgram.awarded.percentage = programNode.payload.liquidityProgram.ownPower * 100 / accumulatedProgramPower
+            programNode.payload.liquidityProgram.awarded.percentage = programNode.payload.liquidityProgram.ownPower * 100 / accumulatedSATokens
             programNode.payload.liquidityProgram.awarded.tokens = programPoolTokenReward * programNode.payload.liquidityProgram.awarded.percentage / 100
 
             drawProgram(programNode)
@@ -188,8 +308,11 @@ function newGovernanceFunctionLibraryLiquidityProgram() {
         function drawProgram(node) {
             if (node.payload !== undefined && node.payload.liquidityProgram.ownPower !== undefined) {
 
-                const ownPowerText = parseFloat(node.payload.liquidityProgram.ownPower.toFixed(2)).toLocaleString('en')
+                const ownPowerText = parseFloat(node.payload.liquidityProgram.ownPower.toFixed(0)).toLocaleString('en')
                 const percentageText = parseFloat(node.payload.liquidityProgram.awarded.percentage.toFixed(2)).toLocaleString('en')
+                
+                //const ownPowerText = parseFloat(node.payload.liquidityProgram.ownPower.toFixed(2)).toLocaleString('en')
+                //const percentageText = parseFloat(node.payload.liquidityProgram.awarded.percentage.toFixed(2)).toLocaleString('en')
 
                 node.payload.uiObject.statusAngleOffset = 0
                 node.payload.uiObject.statusAtAngle = false
@@ -200,7 +323,7 @@ function newGovernanceFunctionLibraryLiquidityProgram() {
 
                 const tokensAwardedText = parseFloat(node.payload.liquidityProgram.awarded.tokens.toFixed(0)).toLocaleString('en')
                 const tokensAwardedBTC = ' ≃ ' + UI.projects.governance.utilities.conversions.estimateSATokensInBTC(node.payload.liquidityProgram.awarded.tokens | 0) + '  BTC'
-
+                
                 node.tokensAwarded.payload.uiObject.valueAngleOffset = 0
                 node.tokensAwarded.payload.uiObject.valueAtAngle = false
 

--- a/Projects/Governance/UI/Function-Libraries/TokenMining.js
+++ b/Projects/Governance/UI/Function-Libraries/TokenMining.js
@@ -125,33 +125,33 @@ function newGovernanceFunctionLibraryTokenMining() {
         }
 
         /* Liquidity Program - Iterate per available asset-exchange-combination */
-        const liqAssets = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_LIQUIDITY_ASSETS
-        const liqExchanges = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_EXCHANGES
+        //const liqAssets = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_LIQUIDITY_ASSETS
+        //const liqExchanges = UI.projects.governance.globals.saToken.SA_TOKEN_BSC_EXCHANGES
         for (let i = 0; i < userProfiles.length; i++) {
             let userProfile = userProfiles[i]
+
             if (userProfile.tokenPowerSwitch === undefined) { continue }
-            for (let liqAsset of liqAssets) {
-                for (let liqExchange of liqExchanges) {
-                    let contractIdentifier = 'UI.projects.governance.globals.saToken.SA_TOKEN_BSC_' + liqExchange + '_LIQUIDITY_POOL_' + liqAsset + '_CONTRACT_ADDRESS'
-                    let marketContract = eval(contractIdentifier)
-                    if (marketContract !== undefined) {
-                        let configPropertyObject = {
-                            "asset": liqAsset,
-                            "exchange": liqExchange
-                        }
-                        let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
-                        /* If nothing found, interpret empty as PANCAKE for backwards compatibility */
-                        if (program === undefined && liqExchange === "PANCAKE") {
-                            configPropertyObject["exchange"] = null
-                            program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject) 
-                        }
-                        if (program === undefined) { continue }
-                        if (program.payload === undefined) { continue }
-                        calculateProgram(userProfile, program, "liquidityProgram")
-                    }
-                } 
+            let liquidityProgramList = UI.projects.governance.globals.saToken.SA_TOKEN_LIQUIDITY_POOL_LIST
+            for (let liqProgram of liquidityProgramList) {
+                let liqAsset = liqProgram['pairedAsset']
+                let liqExchange = liqProgram['exchange']
+                let chain = liqProgram['chain']
+
+                let configPropertyObject = {
+                    "asset": liqAsset,
+                    "exchange": liqExchange
+                }
+                let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
+                /* If nothing found, interpret empty as PANCAKE for backwards compatibility */
+                if (program === undefined && liqExchange === "PANCAKE") {
+                    configPropertyObject["exchange"] = null
+                    program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject) 
+                }
+                if (program === undefined) { continue }
+                if (program.payload === undefined) { continue }
+                calculateProgram(userProfile, program, "liquidityProgram")
             }
-        }
+        } 
 
         for (let i = 0; i < userProfiles.length; i++) {
             let userProfile = userProfiles[i]

--- a/Projects/Governance/UI/Globals/SaToken.js
+++ b/Projects/Governance/UI/Globals/SaToken.js
@@ -11,7 +11,55 @@ function newGovernanceGlobalsSaToken() {
         SA_TOKEN_BSC_BISWAP_LIQUIDITY_POOL_BNB_CONTRACT_ADDRESS: '0xd35b2007438f20088dd84abc27953277487b6e08',
         SA_TOKEN_BSC_1INCH_LIQUIDITY_POOL_BTCB_CONTRACT_ADDRESS: '0x64c5bd3a7ef9384309d6ea229c3a3bfbb6a00216',
         SA_TOKEN_BSC_LIQUIDITY_ASSETS: ['BTCB', 'BNB', 'BUSD', 'ETH'],
-        SA_TOKEN_BSC_EXCHANGES: ['PANCAKE', 'BISWAP', '1INCH']
+        SA_TOKEN_BSC_EXCHANGES: ['PANCAKE', 'BISWAP', '1INCH'],
+        SA_TOKEN_LIST: [
+            {
+                chain: "BSC",
+                contractAddress: "0xfb981ed9a92377ca4d75d924b9ca06df163924fd",
+                treasuryAccountAddress: "0x8d4d2557ce99f83f658adf61eef3e61e04c2ac2c",
+                decimalFactor: 1000000000000000000,
+                ABI: '[{"constant":true,"inputs":[],"name":"name","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_spender","type":"address"},{"name":"_value","type":"uint256"}],"name":"approve","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"totalSupply","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_from","type":"address"},{"name":"_to","type":"address"},{"name":"_value","type":"uint256"}],"name":"transferFrom","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"decimals","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[],"name":"unpause","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"name":"account","type":"address"},{"name":"amount","type":"uint256"}],"name":"mint","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"name":"_value","type":"uint256"}],"name":"burn","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"paused","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_spender","type":"address"},{"name":"_subtractedValue","type":"uint256"}],"name":"decreaseApproval","outputs":[{"name":"success","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"name":"_owner","type":"address"}],"name":"balanceOf","outputs":[{"name":"balance","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"listAddress","type":"address"},{"name":"isBlackListed","type":"bool"}],"name":"blackListAddress","outputs":[{"name":"success","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"pause","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"owner","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"symbol","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_to","type":"address"},{"name":"_value","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"name":"_spender","type":"address"},{"name":"_addedValue","type":"uint256"}],"name":"increaseApproval","outputs":[{"name":"success","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"name":"_owner","type":"address"},{"name":"_spender","type":"address"}],"name":"allowance","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"inputs":[{"name":"_name","type":"string"},{"name":"_symbol","type":"string"},{"name":"_decimals","type":"uint256"},{"name":"_supply","type":"uint256"},{"name":"tokenOwner","type":"address"}],"payable":false,"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Mint","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"burner","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Burn","type":"event"},{"anonymous":false,"inputs":[],"name":"Pause","type":"event"},{"anonymous":false,"inputs":[],"name":"Unpause","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"previousOwner","type":"address"},{"indexed":true,"name":"newOwner","type":"address"}],"name":"OwnershipTransferred","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"blackListed","type":"address"},{"indexed":false,"name":"value","type":"bool"}],"name":"Blacklist","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"owner","type":"address"},{"indexed":true,"name":"spender","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Approval","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"}]'
+            }
+        ],
+        SA_TOKEN_LIQUIDITY_POOL_LIST: [
+            {
+                chain: "BSC",
+                exchange: "PANCAKE",
+                pairedAsset: "BTCB",
+                contractAddress: "0x7164b91db59c50156b63d0e31da08cd47b031711"
+            },
+            {
+                chain: "BSC",
+                exchange: "PANCAKE",
+                pairedAsset: "BNB",
+                contractAddress: "0xd4a05523839d0d175289054022ee4e01e3dae854"
+            },
+            {
+                chain: "BSC",
+                exchange: "PANCAKE",
+                pairedAsset: "BUSD",
+                contractAddress: "0xf9e8ce74058d872f7688665885826c3d5e1d0a27"
+            },
+            {
+                chain: "BSC",
+                exchange: "PANCAKE",
+                pairedAsset: "ETH",
+                contractAddress: "0x4f25B8aB3f8c66Ce4C507C058B7040F6d58202b4"
+            },
+            {
+                chain: "BSC",
+                exchange: "BISWAP",
+                pairedAsset: "BNB",
+                contractAddress: "0xd35b2007438f20088dd84abc27953277487b6e08"
+            },
+            {
+                chain: "BSC",
+                exchange: "1INCH",
+                pairedAsset: "BTCB",
+                contractAddress: "0x64c5bd3a7ef9384309d6ea229c3a3bfbb6a00216"
+            }
+        ]
     }
     return thisObject
 }
+/* Note: SA_TOKEN_BSC_CONTRACT_ADDRESS, SA_TOKEN_BSC_PANCAKE_* ... are on deprecation path. Only use multichain-capable SA_TOKEN_LIST, SA_TOKEN_LIQUIDITY_POOL_LIST going forward */

--- a/Projects/Governance/UI/Spaces/Reports-Space/Liquidity.js
+++ b/Projects/Governance/UI/Spaces/Reports-Space/Liquidity.js
@@ -64,7 +64,7 @@ function newGovernanceReportsLiquidity() {
                     "type": "number",
                     "order": "descending",
                     "textAlign": "center",
-                    "format": "2 decimals"
+                    "format": "integer"
                 },
                 {
                     "name": "percentage",
@@ -97,39 +97,38 @@ function newGovernanceReportsLiquidity() {
         for (let j = 0; j < userProfiles.length; j++) {
             let userProfile = userProfiles[j]
             if (userProfile.tokenPowerSwitch === undefined) { continue }
-            for (let liqAsset of liqAssets) {
-                for (let liqExchange of liqExchanges) {
-                    let contractIdentifier = 'UI.projects.governance.globals.saToken.SA_TOKEN_BSC_' + liqExchange + '_LIQUIDITY_POOL_' + liqAsset + '_CONTRACT_ADDRESS'
-                    let marketContract = eval(contractIdentifier)
-                    if (marketContract !== undefined) {
-                        let configPropertyObject = {
-                            "asset": liqAsset,
-                            "exchange": liqExchange
-                        }
-                        let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
-                        /* If nothing found, interpret empty as PANCAKE for backwards compatibility */
-                        if (program === undefined && liqExchange === "PANCAKE") {
-                            configPropertyObject["exchange"] = null
-                            program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject) 
-                        }
-                        if (program === undefined) { continue }
-                        if (program.payload === undefined) { continue }
-                        if (program.payload[programPropertyName] === undefined) { continue }
-        
-                        let tableRecord = {
-                            "name": userProfile.name,
-                            "market": 'SA / ' + liqAsset,
-                            "exchange": liqExchange,
-                            "liquidityPower": program.payload[programPropertyName].ownPower,
-                            "percentage": program.payload[programPropertyName].awarded.percentage / 100,
-                            "tokensAwarded": program.payload[programPropertyName].awarded.tokens | 0
-                        }
-        
-                        if (UI.projects.governance.utilities.filters.applyFilters(filters, filtersObject, tableRecord) === true) {
-                            tableRecords.push(tableRecord)
-                        }                    
-                    }
+            let liquidityProgramList = UI.projects.governance.globals.saToken.SA_TOKEN_LIQUIDITY_POOL_LIST
+            for (let liqProgram of liquidityProgramList) {
+                let liqAsset = liqProgram['pairedAsset']
+                let liqExchange = liqProgram['exchange']
+                let chain = liqProgram['chain']
+
+                let configPropertyObject = {
+                    "asset": liqAsset,
+                    "exchange": liqExchange
                 }
+                let program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject)
+                /* If nothing found, interpret empty as PANCAKE for backwards compatibility */
+                if (program === undefined && liqExchange === "PANCAKE") {
+                    configPropertyObject["exchange"] = null
+                    program = UI.projects.governance.utilities.validations.onlyOneProgramBasedOnMultipleConfigProperties(userProfile, "Liquidity Program", configPropertyObject) 
+                }
+                if (program === undefined) { continue }
+                if (program.payload === undefined) { continue }
+                if (program.payload[programPropertyName] === undefined) { continue }
+
+                let tableRecord = {
+                    "name": userProfile.name,
+                    "market": 'SA / ' + liqAsset,
+                    "exchange": liqExchange,
+                    "liquidityPower": program.payload[programPropertyName].ownPower,
+                    "percentage": program.payload[programPropertyName].awarded.percentage / 100,
+                    "tokensAwarded": program.payload[programPropertyName].awarded.tokens | 0
+                }
+
+                if (UI.projects.governance.utilities.filters.applyFilters(filters, filtersObject, tableRecord) === true) {
+                    tableRecords.push(tableRecord)
+                }                        
             }
         }
         /*

--- a/Projects/Governance/UI/Spaces/User-Profile-Space/UserProfile.js
+++ b/Projects/Governance/UI/Spaces/User-Profile-Space/UserProfile.js
@@ -188,7 +188,7 @@ function newGovernanceUserProfileSpace() {
                     lastTimestamp: lastTimestamp
                 }
             }
-
+            //UI.projects.foundations.spaces.cockpitSpace.setStatus('Parsing Bitcoin Factory Governance Rewards Data', 1500, UI.projects.foundations.spaces.cockpitSpace.statusTypes.ALL_GOOD)
             httpRequest(JSON.stringify(request.params), request.url, onResponse)
 
             function onResponse(err, data) {

--- a/Projects/Governance/UI/Utilities/Chains.js
+++ b/Projects/Governance/UI/Utilities/Chains.js
@@ -1,0 +1,33 @@
+function newGovernanceUtilitiesChains() {
+    let thisObject = {
+        getSATokenAddress: getSATokenAddress,
+        getSATokenDetails: getSATokenDetails
+    }
+
+    return thisObject
+
+    function getSATokenAddress(chain) {
+        let SATokenAddress = undefined
+        const SATokenList = UI.projects.governance.globals.saToken.SA_TOKEN_LIST
+        for (let tokenConfig of SATokenList) {
+            if (tokenConfig['chain'] === chain) {
+                SATokenAddress = tokenConfig['contractAddress']
+                break
+            }
+        }
+        return SATokenAddress
+    }
+
+    function getSATokenDetails(chain) {
+        let SATokenDetails = undefined
+        const SATokenList = UI.projects.governance.globals.saToken.SA_TOKEN_LIST
+        for (let tokenConfig of SATokenList) {
+            if (tokenConfig['chain'] === chain) {
+                SATokenDetails = tokenConfig
+                break
+            }
+        }
+        return SATokenDetails
+    }
+
+}

--- a/Projects/ProjectsSchema.json
+++ b/Projects/ProjectsSchema.json
@@ -1647,6 +1647,11 @@
                     "name": "Conversions",
                     "propertyName": "conversions",
                     "functionName": "newGovernanceUtilitiesConversions"
+                },
+                {
+                    "name": "Chains",
+                    "propertyName": "chains",
+                    "functionName": "newGovernanceUtilitiesChains"
                 }
             ],
             "spaces": [


### PR DESCRIPTION
This change will introduce the harmonization of Liquidity Pools. By implementing this change, the distribution of rewards will become more fair, as it will no longer be possible to drive rewards for small liquidity pools by voting.

Going forward, liquidity will be rewarded identically, regardless what the paired asset or exchange is. The SA Token acts as the base value to harmonize liquidity across several different assets.

The PR also introduces initial structual enhancements to enable easier extension to other chains beyond BSC.

Note: Please merge the Governance-Plugins repo in timely proximity, as missing pools will otherwise lead to breaking changes.