### PR TITLE
Disabling Unit Tests for the Contributions Space

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run unitTest
+if [ "$UNITTESTS" != "false" ]
+then
+    npm run unitTest
+fi

--- a/Platform/Client/httpInterface.js
+++ b/Platform/Client/httpInterface.js
@@ -1228,7 +1228,11 @@ exports.newHttpInterface = function newHttpInterface() {
                                             await git.pull('origin', currentBranch)
                                             await git.add('./*')
 
-                                            await git.commit(messageToSend)
+                                            /* Deactivate Unit Tests for the Contributions Space by setting UNITTESTS environment variable within the commit call. */
+                                            const UNITTESTS = 'false'
+                                            await git
+                                            .env({...process.env, UNITTESTS})
+                                            .commit(messageToSend)
 
                                             await git.push('origin', currentBranch)
                                         } catch (err) {
@@ -1450,7 +1454,11 @@ exports.newHttpInterface = function newHttpInterface() {
                                         try {
                                             await git.pull('origin', currentBranch)
                                             await git.add('./*')
-                                            await git.commit(commitMessage)
+                                            /* Deactivate Unit Tests for the Contribution Space by setting UNITTESTS environment variable within the commit call. */
+                                            const UNITTESTS = 'false'
+                                            await git
+                                            .env({...process.env, UNITTESTS})
+                                            .commit(commitMessage)
                                             await git.push('origin', currentBranch)
                                         } catch (err) {
                                             console.log((new Date()).toISOString(), '[ERROR] httpInterface -> App -> Contribute -> doGit -> Method call produced an error.')

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "installDesktopReact": "cd ./DesktopReact && npm ci",
     "startLocalDesktopReact": "start npm run startNetwork && cd ./DesktopReact && start npm run startDesktopReactBackend && start npm run startDesktopReactFrontend",
     "startDesktopReact": "cd ./DesktopReact && start npm run startDesktopReactBackend && start npm run startDesktopReactFrontend",
-    "unitTest": "NODE_OPTIONS='--max_old_space_size=3072' jest --silent",
+    "unitTest": "node --max_old_space_size=3072 ./node_modules/.bin/jest --silent",
     "unitTest:coverage": "jest --silent --coverage",
     "unitTest:debug": "DEBUG=nock.* jest",
     "lintAll": "eslint . --ext .js",


### PR DESCRIPTION
Introducing new environment variable UNITTESTS which allows to deactivate unit tests by setting the variable to "false".

For the time being, we are setting status "false" for all commits made via the contributions space. Unit tests remain active for command line commits.