### PR TITLE
Fix for Network Node Multiple Test Servers Working

### DIFF
--- a/Projects/Bitcoin-Factory/NT/Modules/ClientInterface.js
+++ b/Projects/Bitcoin-Factory/NT/Modules/ClientInterface.js
@@ -212,9 +212,9 @@ exports.newBitcoinFactoryModulesClientInterface = function newBitcoinFactoryModu
                     for (let i = 0; i < requestsToServer.length; i++) {
                         let requestToServer = requestsToServer[i]
                         if (
-                            requestToServer.testServer !== undefined &&
-                            requestToServer.testServer.userProfile === userProfile &&
-                            requestToServer.testServer.instance === queryReceived.instance
+                            requestToServer.queryReceived.testServer !== undefined &&
+                            requestToServer.queryReceived.testServer.userProfile === userProfile &&
+                            requestToServer.queryReceived.testServer.instance === queryReceived.instance
                         ) {
                             requestsToServer.splice(i, 1)
                             checkExpiration(requestToServer)


### PR DESCRIPTION
Fixed a error that was causing the network node to mix up what server it should send finished test case results to.