### PR TITLE
Deactivating Unit Tests due to jest memory handling issue

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,8 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-if [ "$UNITTESTS" != "false" ]
-then
-    npm run unitTest
-fi
+# Disabling unit tests until resolution of jest memory issue - https://github.com/facebook/jest/issues/11956
+# if [ "$UNITTESTS" != "false" ]
+# then
+#     npm run unitTest
+# fi

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "installDesktopReact": "cd ./DesktopReact && npm ci",
     "startLocalDesktopReact": "start npm run startNetwork && cd ./DesktopReact && start npm run startDesktopReactBackend && start npm run startDesktopReactFrontend",
     "startDesktopReact": "cd ./DesktopReact && start npm run startDesktopReactBackend && start npm run startDesktopReactFrontend",
-    "unitTest": "node --max_old_space_size=3072 ./node_modules/.bin/jest --silent",
+    "unitTest": "jest --silent",
     "unitTest:coverage": "jest --silent --coverage",
     "unitTest:debug": "DEBUG=nock.* jest",
     "lintAll": "eslint . --ext .js",


### PR DESCRIPTION
This temporarily deactivates unit testing for all commit methods due to a memory handling issue in jest, combined with node versions > 16.10.

Jest is having a fix in progress, which though is not published into a stable version as of now. The issue can be tracked here:
https://github.com/facebook/jest/issues/11956