### PR TITLE
Fix for chart candle colors

### DIFF
--- a/Platform/UI/Data-Files/FileCursor.js
+++ b/Platform/UI/Data-Files/FileCursor.js
@@ -588,6 +588,8 @@ function newFileCursor() {
         if (chartingSpaceNode !== undefined) {
             if (chartingSpaceNode.spaceStyle !== undefined) {
                 configStyle = JSON.parse(chartingSpaceNode.spaceStyle.config)
+            } else {
+              configStyle = undefined
             }
         } else {
             configStyle = undefined

--- a/Projects/Foundations/Bots-Plotters-Code/Candles/plotters/Plotters-Candles-Volumes/Candles.js
+++ b/Projects/Foundations/Bots-Plotters-Code/Candles/plotters/Plotters-Candles-Volumes/Candles.js
@@ -691,6 +691,8 @@
                         if (chartingSpaceNode !== undefined) {
                             if (chartingSpaceNode.spaceStyle !== undefined) {
                                 configStyle = JSON.parse(chartingSpaceNode.spaceStyle.config)
+                            } else {
+                                configStyle = undefined
                             }
                         } else {
                             configStyle = undefined


### PR DESCRIPTION
This fix's the problem with how candles are colored if the Space Style node is not present. I will PR the same fix to the other less / non effected files in the near future.