### PR TITLE
Governance: Dymamic Gas Fee Handling for ETH Distributions

### DIFF
--- a/Platform/Client/web3Server.js
+++ b/Platform/Client/web3Server.js
@@ -335,6 +335,22 @@ exports.newWeb3Server = function newWeb3Server() {
         }
     }
 
+    async function getGasPrice() {
+        const axios = SA.nodeModules.axios
+        const url = 'https://api.etherscan.io/api?module=gastracker&action=gasoracle'
+
+        try {
+            let response = await axios.get(url)
+            if (response.data.result.ProposeGasPrice !== undefined) {
+                return parseInt(response.data.result.ProposeGasPrice)
+            } else {
+                return undefined
+            }
+        } catch(err) {
+            console.log("Gas Price Query Error: ", err)
+        }
+    }
+
     async function recoverAddress(signature) {
         try {
             let signatureObject = JSON.parse(signature)
@@ -529,12 +545,38 @@ exports.newWeb3Server = function newWeb3Server() {
                             return
                     }                    
 
+                    /* Default Gas Price for all chains but ETH */
+                    let gasPrice = 5000000000
+
+                    /* If executing on ETH, verify if current gas price is within reasonable range and calculate price for transaction */
+                    if (chain === 'ETH') {
+                        /* Maximum gas price in Gwei we are ready to pay */
+                        const gasPriceLimit = 15
+                        let gasFeeOk = false
+                        while (gasFeeOk === false) {
+                            let currentGasPrice = await getGasPrice();
+                            if (currentGasPrice === undefined) {
+                                console.log("Could not obtain current gas price, retrying in 60 seconds...")
+                                await SA.projects.foundations.utilities.asyncFunctions.sleep(60000)
+                            } else if (currentGasPrice > gasPriceLimit) {
+                                console.log("Current Gas Price", currentGasPrice, "Gwei exceeding limit of", gasPriceLimit, "Gwei. Holding transaction, retrying in 60 seconds...")
+                                await SA.projects.foundations.utilities.asyncFunctions.sleep(60000)
+                            } else if (currentGasPrice > 0 && currentGasPrice <= gasPriceLimit) {
+                                console.log("Current Gas Price", currentGasPrice, "Gwei, executing transaction.")
+                                /* Conversion to Wei */
+                                gasPrice = currentGasPrice * 1000000000
+                                gasFeeOk = true
+                            }
+                        }
+                    }
+                    
+                    
                     const nonce = await web3.eth.getTransactionCount(fromAddress);
                     console.log('Nonce:', nonce)
 
                     const rawTransaction = {
                         "from": fromAddress,
-                        "gasPrice": web3.utils.toHex(5000000000),
+                        "gasPrice": web3.utils.toHex(gasPrice),
                         "gasLimit": web3.utils.toHex(210000),
                         "to": contractAddressDict[chain], "value": "0x0",
                         "data": contract.methods.transfer(toAddress, amountBigNumber).encodeABI(),

--- a/Platform/Client/web3Server.js
+++ b/Platform/Client/web3Server.js
@@ -561,7 +561,7 @@ exports.newWeb3Server = function newWeb3Server() {
                             } else if (currentGasPrice > gasPriceLimit) {
                                 console.log("Current Gas Price", currentGasPrice, "Gwei exceeding limit of", gasPriceLimit, "Gwei. Holding transaction, retrying in 60 seconds...")
                                 await SA.projects.foundations.utilities.asyncFunctions.sleep(60000)
-                            } else if (currentGasPrice > 0 && currentGasPrice <= gasPriceLimit) {
+                            } else if (currentGasPrice > 0) {
                                 console.log("Current Gas Price", currentGasPrice, "Gwei, executing transaction.")
                                 /* Conversion to Wei */
                                 gasPrice = currentGasPrice * 1000000000


### PR DESCRIPTION
This new logic obtains the current gas fee before broadcasting a new transaction to the blockchain when running a distribution on ETH. The gas price settings for the next transaction is adjusted accordingly.

If the current market rate is above the defined limit (currently 15 Gwei), the broadcasting of further transactions is paused until the market rate falls below the limit - retries every 60 seconds.