### PR TITLE
Network node connection choice upgrade

### DIFF
--- a/Projects/Network/SA/Modules/P2PNetworkReachableNodes.js
+++ b/Projects/Network/SA/Modules/P2PNetworkReachableNodes.js
@@ -36,9 +36,30 @@ exports.newNetworkModulesP2PNetworkReachableNodes = function newNetworkModulesP2
         switch (callerRole) {
             case 'Network Client': {
                 thisObject.p2pNodesToConnect = []
+                
+                let connectOnlyRequestedUserProfile = false
+                let connectOnlyProfile
+
+                // First we grab any config options from our own user profiles.
+                for (let i = 0; i < SA.projects.network.globals.memory.arrays.P2P_NETWORK_NODES.length; i++) {
+                    let p2pNetworkNode = SA.projects.network.globals.memory.arrays.P2P_NETWORK_NODES[i]
+                    if (p2pNetworkNode.userProfile.name === userProfileCodeName) {
+                        if (p2pNetworkNode.node.config.networkNodeUserProfile !== undefined) {
+                            connectOnlyProfile = p2pNetworkNode.node.config.networkNodeUserProfile
+                            connectOnlyRequestedUserProfile = true
+                            break
+                        } else { continue }
+                    }
+                }
+
 
                 for (let i = 0; i < SA.projects.network.globals.memory.arrays.P2P_NETWORK_NODES.length; i++) {
                     let p2pNetworkNode = SA.projects.network.globals.memory.arrays.P2P_NETWORK_NODES[i]
+
+                    // If we have a defined network node profile to connect to we will only check that profile.
+                    if (connectOnlyRequestedUserProfile) {
+                        if (p2pNetworkNode.userProfile.name !== connectOnlyProfile) { continue }
+                    }
 
                     if (p2pNetworkNode.node.p2pNetworkReference.referenceParent === undefined) { continue }
                     if (p2pNetworkNode.node.p2pNetworkReference.referenceParent.config === undefined) { continue }

--- a/Projects/Network/Schemas/Docs-Nodes/P/P2P/P2P-Network-Node/p2p-network-node.json
+++ b/Projects/Network/Schemas/Docs-Nodes/P/P2P/P2P-Network-Node/p2p-network-node.json
@@ -14,7 +14,7 @@
     "paragraphs": [
         {
             "style": "Text",
-            "text": "Right click and select the pencil button to enter edit mode.",
+            "text": "codeName : The usual code name is \"P2P-Network-Node-1\"",
             "translations": [
                 {
                     "language": "TR",
@@ -22,7 +22,23 @@
                     "updated": 1654395784506,
                     "style": "Text"
                 }
-            ]
+            ],
+            "updated": 1665800632070
+        },
+        {
+            "style": "Text",
+            "text": "host : The usual host name is \"localhost\"",
+            "updated": 1665800660470
+        },
+        {
+            "style": "Text",
+            "text": "clientMinimunBalance : This is the minimum wallet SA balance required to connect to your network node",
+            "updated": 1665800802229
+        },
+        {
+            "style": "Text",
+            "text": "networkNodeUserProfile : (Optional) This is the user name of a particular network node you wish to connect to.",
+            "updated": 1665801005810
         }
     ]
 }


### PR DESCRIPTION
This upgrade allows users to specify a specific network node to try to connect to. 
A new optional config option was added to the P2P Network Node config located at our user profiles.
Example:

"networkNodeUserProfile": "theblockchainarborist"

All checks are still done on the network node, including the needed token balance to connect.