### PR TITLE
P2P Network : new P2P Network Node Reference node

### DIFF
--- a/Projects/Foundations/UI/Node-Action-Functions/TaskFunctions.js
+++ b/Projects/Foundations/UI/Node-Action-Functions/TaskFunctions.js
@@ -222,6 +222,7 @@ function newFoundationsFunctionLibraryTaskFunctions() {
             */
             'P2P Network Client->' +
             'P2P Network Reference->Permissioned P2P Network->P2P Network->' +
+            'P2P Network Node Reference->P2P Network Node->' +
             'Network Services->Social Graph->Machine Learning->Trading Signals->Online Workspaces->' +
             'Network Interfaces->Websockets Network Interface->Webrtc Network Interface->Http Network Interface->'
 

--- a/Projects/Network/SA/Modules/P2PNetworkReachableNodes.js
+++ b/Projects/Network/SA/Modules/P2PNetworkReachableNodes.js
@@ -37,31 +37,33 @@ exports.newNetworkModulesP2PNetworkReachableNodes = function newNetworkModulesP2
             case 'Network Client': {
                 thisObject.p2pNodesToConnect = []
                 
-                let connectOnlyRequestedUserProfile = false
-                let connectOnlyProfile
+                let connectOnlyRequestedToP2pNode = false
+                let connectOnlyToP2pNode
 
                 /*
-                // We will check the p2pNetworkClient node located at this task for a specified network node to connect this task to.
-                // If a specific network node is requested then it will be the only available network node to that task.
+                We will check the p2pNetworkClient node located at this task for a specified network node to connect this task to.
+                If a specific network node is requested then it will be the only available network node to that task.
                 */
                 if (p2pNetworkClientNode !== undefined) {
-                    if (p2pNetworkClientNode.config !== undefined) {
-                        if (p2pNetworkClientNode.config.onlyConnectToNetworkNodeFromUserProfile !== undefined) {
-                            connectOnlyProfile = p2pNetworkClientNode.config.onlyConnectToNetworkNodeFromUserProfile
-                            connectOnlyRequestedUserProfile = true
+                    if (p2pNetworkClientNode.p2pNetworkNodeReference !== undefined) {
+                        if (p2pNetworkClientNode.p2pNetworkNodeReference.referenceParent !== undefined) {
+                            if (p2pNetworkClientNode.p2pNetworkNodeReference.referenceParent.id !== undefined) {
+                                connectOnlyToP2pNode = p2pNetworkClientNode.p2pNetworkNodeReference.referenceParent
+                                connectOnlyRequestedToP2pNode = true
+                            }
+                        }
                         }
                     }
-                } else {
+                else {
                     console.log('[ERROR] The P2P Network Client node is required at each task. Please add the node and try again.')
                 }
-
 
                 for (let i = 0; i < SA.projects.network.globals.memory.arrays.P2P_NETWORK_NODES.length; i++) {
                     let p2pNetworkNode = SA.projects.network.globals.memory.arrays.P2P_NETWORK_NODES[i]
 
                     // If we have a defined network node profile to connect to we will only check that profile.
-                    if (connectOnlyRequestedUserProfile) {
-                        if (p2pNetworkNode.userProfile.name !== connectOnlyProfile) { continue }
+                    if (connectOnlyRequestedToP2pNode) {
+                        if (p2pNetworkNode.node.id !== connectOnlyToP2pNode.id) { continue }
                     }
 
                     if (p2pNetworkNode.node.p2pNetworkReference.referenceParent === undefined) { continue }

--- a/Projects/Network/Schemas/App-Schema/p2p-network-client.json
+++ b/Projects/Network/Schemas/App-Schema/p2p-network-client.json
@@ -24,6 +24,16 @@
             "action": "Add UI Object",
             "actionProject": "Visual-Scripting",
             "disableIfPropertyIsDefined": true,
+            "propertyToCheckFor": "p2pNetworkNodeReference",
+            "actionFunction": "payload.executeAction",
+            "label": "Add P2P Network Node Reference",
+            "relatedUiObject": "P2P Network Node Reference",
+            "relatedUiObjectProject": "Network"
+        },
+        {
+            "action": "Add UI Object",
+            "actionProject": "Visual-Scripting",
+            "disableIfPropertyIsDefined": true,
             "propertyToCheckFor": "networkServices",
             "actionFunction": "payload.executeAction",
             "label": "Add Network Services",
@@ -67,6 +77,13 @@
             "name": "p2pNetworkReference",
             "type": "node",
             "childType": "P2P Network Reference",
+            "project": "Network",
+            "autoAdd": true
+        },
+        {
+            "name": "p2pNetworkNodeReference",
+            "type": "node",
+            "childType": "P2P Network Node Reference",
             "project": "Network",
             "autoAdd": true
         },

--- a/Projects/Network/Schemas/App-Schema/p2p-network-node-reference.json
+++ b/Projects/Network/Schemas/App-Schema/p2p-network-node-reference.json
@@ -1,0 +1,27 @@
+{
+    "type": "P2P Network Node Reference",
+    "menuItems": [
+        {
+            "action": "Delete UI Object",
+            "actionProject": "Visual-Scripting",
+            "askConfirmation": true,
+            "confirmationLabel": "Confirm to Delete",
+            "label": "Delete",
+            "iconPathOn": "delete-entity",
+            "iconPathOff": "delete-entity",
+            "actionFunction": "payload.executeAction"
+        }
+    ],
+    "title": [
+        "Use Reference Parent"
+    ],
+    "addLeftIcons": true,
+    "level": 2,
+    "attachingRules": {
+        "compatibleTypes": "->P2P Network Client->"
+    },
+    "referencingRules": {
+        "compatibleTypes": "->P2P Network Node->"
+    },
+    "propertyNameAtParent": "p2pNetworkNodeReference"
+}


### PR DESCRIPTION
Previous PR introduced the possibility to connect to a specific user P2p Network Node using by adding this key to the P2p Network Client Node : 
```json
"onlyConnectToNetworkNodeFromUserProfile": "vraptor75011"
```
![Capture d’écran 2022-10-18 à 12 16 05](https://user-images.githubusercontent.com/658580/196406071-e2672235-7a41-4c70-a981-ec4dfbb41b6b.png)

It is now replaced with the implementation of a node called P2p Network Node Reference to be added to the P2p Network Client Node and referencing the user profile P2p Network Node : 

![Capture d’écran 2022-10-18 à 12 13 33](https://user-images.githubusercontent.com/658580/196406083-6f6fd356-c453-46fc-b410-91fa81231f31.png)
