### PR TITLE
Bug Fix Charting Space Themes

### DIFF
--- a/Projects/Foundations/UI/Spaces/Panel-Space/PlotterPanel.js
+++ b/Projects/Foundations/UI/Spaces/Panel-Space/PlotterPanel.js
@@ -24,6 +24,8 @@ function newPlotterPanel() {
     let upDownButton
     let panelNode
     let recordSet = new Map()
+    let configStyle
+
 
     return thisObject
 
@@ -159,6 +161,15 @@ function newPlotterPanel() {
                 }
             }
 
+            let chartingSpaceNode = UI.projects.workspaces.spaces.designSpace.workspace.getHierarchyHeadByNodeType('Charting Space')
+            if (chartingSpaceNode !== undefined) {
+                if (chartingSpaceNode.spaceStyle !== undefined) {
+                    configStyle = JSON.parse(chartingSpaceNode.spaceStyle.config)
+                }
+            } else {
+                configStyle = undefined
+            }
+
 
             if (valuePosition > 100) {thisObject.container.frame.height = UI_PANEL.HEIGHT.NORMAL * 1.25}
             
@@ -207,10 +218,14 @@ function newPlotterPanel() {
                     textSize = 14
                 } 
                 case (textColor): {
-                    textColor = UI_COLOR.DARK
+                    if (configStyle === undefined || configStyle.indicatorFrameTextColor === undefined) {
+                        textColor = UI_COLOR.DARK
+                    } else {
+                        textColor = eval(configStyle.indicatorFrameTextColor)
+                    }
                 } 
                 case (valueColor): {
-                    valueColor = UI_COLOR.DARK
+                    valueColor = textColor
                 }
                 case (valueOpacity): {
                     valueOpacity = '1'


### PR DESCRIPTION
Resolved a bug that caused the text in the indicator panels to be hard to see when using a dark theme.
That text's default color can now be set with the already existing "indicatorFrameTextColor" config option.
If no color is defined the default will be the normal dark color,
If it is defined it can still be overridden by and Data Mine that specifies a text color.