### PR TITLE
P2P Network: Stability Improvements

### DIFF
--- a/Network/NetwokApp.js
+++ b/Network/NetwokApp.js
@@ -26,7 +26,7 @@ exports.newNetworkApp = function newNetworkApp() {
         console.log('Network Node User Profile Code Name .......................................... ' + thisObject.p2pNetworkNode.userProfile.config.codeName)
         console.log('Network Node User Profile Balance ............................................ ' + SA.projects.governance.utilities.balances.toSABalanceString(thisObject.p2pNetworkNode.userProfile.balance))
         console.log('Network Node Code Name ....................................................... ' + thisObject.p2pNetworkNode.node.config.codeName)
-        console.log('Minimun User Profile Balance Required to Connect to this Network Node ........ ' + SA.projects.governance.utilities.balances.toSABalanceString(thisObject.p2pNetworkNode.node.config.clientMinimunBalance))
+        console.log('Minimum User Profile Balance Required to Connect to this Network Node ........ ' + SA.projects.governance.utilities.balances.toSABalanceString(thisObject.p2pNetworkNode.node.config.clientMinimunBalance))
         console.log('Network Node Version ......................................................... ' + NETWORK_NODE_VERSION)
         console.log('Network Type ................................................................. ' + thisObject.p2pNetworkNode.node.p2pNetworkReference.referenceParent.type)
         console.log('Network Code Name ............................................................ ' + thisObject.p2pNetworkNode.node.p2pNetworkReference.referenceParent.config.codeName)

--- a/Projects/Bitcoin-Factory/NT/Modules/ClientInterface.js
+++ b/Projects/Bitcoin-Factory/NT/Modules/ClientInterface.js
@@ -328,11 +328,12 @@ exports.newBitcoinFactoryModulesClientInterface = function newBitcoinFactoryModu
     /* Statistics & Maintenance functions to be executed once a minute */
     function statsMaintenance() {
         maintainMemoryStorage()
+        /*  Commenting this block for now not to have the log too verbose, move to dashboard later
+
         let testServerList
         let forecasterList
         if (activeTestServerOperators.size === 0) { testServerList = "none" } else { testServerList = Array.from(activeTestServerOperators).join(', ') }
         if (activeForecasterOperators.size === 0) { forecasterList = "none" } else { forecasterList = Array.from(activeForecasterOperators).join(', ') }
-        /*
         console.log((new Date()).toISOString(), '[INFO] Active Test Server Operators: ', testServerList)
         console.log((new Date()).toISOString(), '[INFO] Active Forecaster Operators: ', forecasterList)
         */

--- a/Projects/Bitcoin-Factory/NT/Modules/ClientInterface.js
+++ b/Projects/Bitcoin-Factory/NT/Modules/ClientInterface.js
@@ -248,7 +248,22 @@ exports.newBitcoinFactoryModulesClientInterface = function newBitcoinFactoryModu
                         }
                     }
                     /*
-                    There are not request specific for this Test Server Instance, so we can assing the next generic one.
+                    Workaround: The Forecaster is submitting cases with instance name, but without userProfile. Delete this 
+                    block after this issue has been fixed at the source and old test cases were processed
+                    */
+                    for (let i = 0; i < requestsToServer.length; i++) {
+                        let requestToServer = requestsToServer[i]
+                        if (
+                            requestToServer.queryReceived.testServer !== undefined &&
+                            requestToServer.queryReceived.testServer.instance === queryReceived.instance
+                        ) {
+                            requestsToServer.splice(i, 1)
+                            checkExpiration(requestToServer)
+                            return
+                        }
+                    }
+                    /*
+                    There are no requests specific for this Test Server Instance, so we can assign the next generic one.
                     */
                     for (let i = 0; i < requestsToServer.length; i++) {
                         let requestToServer = requestsToServer[i]

--- a/Projects/Bitcoin-Factory/TS/Bot-Modules/Test-Server/TestServer.js
+++ b/Projects/Bitcoin-Factory/TS/Bot-Modules/Test-Server/TestServer.js
@@ -80,8 +80,8 @@
                     return
                 }
                 if (TS.projects.foundations.globals.taskConstants.P2P_NETWORK.p2pNetworkClient.machineLearningNetworkServiceClient === undefined) {
-                    console.log((new Date()).toISOString(), "Not connected to the Superalgos Network.")
-                    await SA.projects.foundations.utilities.asyncFunctions.sleep(5000)
+                    console.log((new Date()).toISOString(), "Not connected to the Superalgos Network. Retrying in 10 seconds...")
+                    await SA.projects.foundations.utilities.asyncFunctions.sleep(10000)
                 } else {
                     await TS.projects.foundations.globals.taskConstants.P2P_NETWORK.p2pNetworkClient.machineLearningNetworkServiceClient.sendMessage(messageHeader)
                         .then(onSuccess)
@@ -150,9 +150,11 @@
                         }
                     }
                     async function onError(err) {
-                        console.log((new Date()).toISOString(), 'Error retrieving message from Network Node. ')
+                        console.log((new Date()).toISOString(), 'Error retrieving message from Network Node.')
                         console.log((new Date()).toISOString(), 'err: ' + err)
+                        console.log((new Date()).toISOString(), 'Retrying in 10 seconds...')
                         getReadyForNewMessage()
+                        await SA.projects.foundations.utilities.asyncFunctions.sleep(10000)
                     }
                 }
             }

--- a/Projects/Network/NT/Modules/SocketInterfaces.js
+++ b/Projects/Network/NT/Modules/SocketInterfaces.js
@@ -33,11 +33,9 @@ exports.newNetworkModulesSocketInterfaces = function newNetworkModulesSocketInte
             for (let i = 0; i < thisObject.networkClients.length; i++) {
                 let caller = thisObject.networkClients[i]
                 let diff = Math.trunc((now - caller.timestamp) / 60 / 1000)
-                if (diff > 2) {
+                if (diff > 30) {
                     caller.socket.close()
-
-                    console.log((new Date()).toISOString(), '[WARN] Socket Interfaces -> cleanIdleConnections -> Client Idle by more than ' + diff + ' minutes -> caller.userProfile.name = ' + caller.userProfile.name)
-                    return
+                    console.log((new Date()).toISOString(), '[INFO] Socket Interfaces -> cleanIdleConnections -> Client Idle by more than ' + diff + ' minutes -> caller.userProfile.name = ' + caller.userProfile.name)
                 }
             }
         }

--- a/Projects/Network/NT/Modules/WebSocketsInterface.js
+++ b/Projects/Network/NT/Modules/WebSocketsInterface.js
@@ -59,7 +59,7 @@ exports.newNetworkModulesWebSocketsInterface = function newNetworkModulesWebSock
                 caller.socket.on('pong', heartbeat)
                 const interval = setInterval(function ping() {
                     if (caller.socket.isAlive === false) {
-                        console.log((new Date()).toISOString(), '[INFO] Server could not confirm client to be alive, re-initializing Websockets connection for user ', caller.userProfile.name)
+                        console.log((new Date()).toISOString(), '[INFO] Server could not confirm client to be alive, terminating Websockets connection for user ', caller.userProfile.name)
                         return caller.socket.terminate()
                     }
                     /* console.log((new Date()).toISOString(), '[DEBUG] Server-side heartbeat triggered for ', caller.userProfile.name, caller.socket.id) */

--- a/Projects/Network/SA/Modules/P2PNetworkNodesConnectedTo.js
+++ b/Projects/Network/SA/Modules/P2PNetworkNodesConnectedTo.js
@@ -43,6 +43,7 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
     ) {
 
         thisObject.peers = []
+        thisObject.peersWaitingForConnection = []
 
         connectToPeers()
         intervalIdConnectToPeers = setInterval(connectToPeers, RECONNECT_DELAY)
@@ -71,7 +72,13 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
                 if (isPeerConnected(peer) === true) {
                     continue
                 }
+                /* Check for pending connection requests to avoid duplicate connections */
+                if (thisObject.peersWaitingForConnection.includes(peer.p2pNetworkNode)) {
+                    console.log((new Date()).toISOString(), '[INFO] Awaiting response to earlier connection attempt, skipping new connection request...')
+                    continue
+                }
                 peer.webSocketsClient = SA.projects.network.modules.webSocketsNetworkClient.newNetworkModulesWebSocketsNetworkClient()
+                thisObject.peersWaitingForConnection.push(peer.p2pNetworkNode)
                 await peer.webSocketsClient.initialize(
                     callerRole,
                     p2pNetworkClientIdentity,
@@ -83,10 +90,12 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
                     .catch(onError)
 
                 function addPeer() {
+                    onFinalizedConnectionRequest()
                     thisObject.peers.push(peer)
                 }
 
                 function onError(err) {
+                    onFinalizedConnectionRequest()
                     if (err !== undefined) {
                         console.log((new Date()).toISOString(), '[ERROR] P2P Network Peers -> onError -> While connecting to node -> ' + peer.p2pNetworkNode.userProfile.config.codeName + ' -> ' + peer.p2pNetworkNode.node.name + ' -> ' + err.message)
                     } else {
@@ -96,6 +105,14 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
                         /*                  
                         console.log((new Date()).toISOString(), '[WARN] P2P Network Peers -> onError -> Peer Not Available at the Moment -> ' + peer.p2pNetworkNode.userProfile.config.codeName + ' -> ' + peer.p2pNetworkNode.node.name)
                         */
+                    }
+                }
+
+                /* After a connection is established, remove the peer from the array of connections-in-progress */
+                function onFinalizedConnectionRequest() {
+                    let index = thisObject.peersWaitingForConnection.indexOf(peer.p2pNetworkNode)
+                    if (index > -1) {
+                        thisObject.peersWaitingForConnection.splice(index, 1)
                     }
                 }
 

--- a/Projects/Network/SA/Modules/P2PNetworkReachableNodes.js
+++ b/Projects/Network/SA/Modules/P2PNetworkReachableNodes.js
@@ -90,7 +90,7 @@ exports.newNetworkModulesP2PNetworkReachableNodes = function newNetworkModulesP2
                     let clientMinimunBalance = p2pNetworkNode.node.config.clientMinimunBalance | 0
                     if (userProfileBalance < clientMinimunBalance) {
                         console.log('')
-                        console.log((new Date()).toISOString(), '[INFO] Network Client User Profile ' + userProfileCodeName + ' has a Balance of ' + SA.projects.governance.utilities.balances.toSABalanceString(userProfileBalance) + ' while the Minimun Balance Required to connect to the Network Node "' + p2pNetworkNode.userProfile.config.codeName + '/' + p2pNetworkNode.node.config.codeName + '" is ' + SA.projects.governance.utilities.balances.toSABalanceString(clientMinimunBalance) + '. If you want to be able to connect to this Network Node you will need to earn or buy more SA tokens and try again.')
+                        console.log((new Date()).toISOString(), '[INFO] Network Client User Profile ' + userProfileCodeName + ' has a Balance of ' + SA.projects.governance.utilities.balances.toSABalanceString(userProfileBalance) + ' while the Minimum Balance Required to connect to the Network Node "' + p2pNetworkNode.userProfile.config.codeName + '/' + p2pNetworkNode.node.config.codeName + '" is ' + SA.projects.governance.utilities.balances.toSABalanceString(clientMinimunBalance) + '. If you want to be able to connect to this Network Node you will need to earn or buy more SA tokens and try again.')
                         console.log('')
                         continue
                     }
@@ -98,7 +98,7 @@ exports.newNetworkModulesP2PNetworkReachableNodes = function newNetworkModulesP2
                     checkForPermissions(p2pNetworkNode)
                 }
 
-                console.log((new Date()).toISOString(), '[INFO] These are the P2P Network Nodes we can connect to: all nodes that do not have the network services and network interfaces defined required by the Network Client were filtered out. Network nodes that requires a minimun User Profile Balance than the one you have also been filtered out.')
+                console.log((new Date()).toISOString(), '[INFO] These are the P2P Network Nodes we can connect to: all nodes that do not have the network services and network interfaces defined required by the Network Client were filtered out. Network nodes that require a higher minimum User Profile Balance than the one you have also were filtered out.')
                 console.log('')
                 for (let i = 0; i < thisObject.p2pNodesToConnect.length; i++) {
                     console.log(i + ' - ' + thisObject.p2pNodesToConnect[i].userProfile.config.codeName + ' - ' + thisObject.p2pNodesToConnect[i].node.config.codeName)

--- a/Projects/Network/SA/Modules/WebSocketsNetworkClient.js
+++ b/Projects/Network/SA/Modules/WebSocketsNetworkClient.js
@@ -106,13 +106,15 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
                     return
                 }
 
-                /* This function awaits a heartbeat from the server every 30 seconds + 3 seconds grace and re-initializes if not received. Prevents hidden connection drops. Ensure timeout matches with WebSocketsInterface.js */
+                /* This function awaits a heartbeat from the server every 30 seconds + 15 seconds grace and re-initializes if not received. Prevents hidden connection drops. Ensure timeout matches with WebSocketsInterface.js
+                Longer grace period is required due to large Bitcoin Factory files being transferred, this blocking the connection for the ping for a little while. 
+                */
                 function heartbeat() {
                     clearTimeout(socket.pingTimeout)
                     socket.pingTimeout = setTimeout(() => {
                         console.log((new Date()).toISOString(), '[INFO] No Websockets heartbeat received from server, re-initializing connection...')
                         socket.terminate()
-                    }, 30000 + 3000)
+                    }, 30000 + 15000)
                 }
 
             } catch (err) {


### PR DESCRIPTION
- Grace period for Websockets Heartbeat Pings increased for Bitcoin Factory, as the larger file transfers were blocking pings and causing timeouts
- Logic added to avoid redundant Websockets connections from getting established during temporary network outages
- Correcting a few typos in output messages
- Fixing an issue which caused Forecaster messages to remain stuck at the network node indefinitely
- Improving TestServer so it survives connection interruptions to the network node without need for a restart
- Adding logic at network node to delete messages older than 2 minutes from the queue, this to avoid test servers to be flooded with old stuff after reconnecting