### PR TITLE
Cloud aws docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ We will briefly describe the options available. Click the link to go to the spec
 
 4. [Raspberry Pi](README_RaspberryPi.md) | Raspberry Pi installations are a great economical option for running a trading system. You will need to be comfortable with either options 2 or 3 above to proceed here.
 
+5. [Public Cloud](README_PublicCloud.md) | This is a great option for those who wish to run a trading system in the cloud. You will need to be comfortable with option 3 above to proceed here.
+
 > :white_check_mark: **ABOUT REMOTE INSTALLATIONS AND MINIMALIST HARDWARE:** Remote installations and minimalist hardware — both virtual and physical — are better suited for production deployments, where the use of the GUI is minimal. We highly recommend learning Superalgos in a local installation, on a full-size PC. Mastering the system takes time, and the use of the GUI to go through in-app tutorials is crucial during the learning process. Your experience will be orders of magnitude better if you follow this advice: leave remote installations and minimalist hardware for when you are ready to start trading live.
 
 > :white_check_mark: **EXPERIENCING ISSUES INSTALLING SUPERALGOS?** If you're having trouble installing or running the app for the first time, do not open an issue. Instead, join the [Support Telegram Group](https://t.me/superalgossupport) and follow the instructions on the pinned message to ask for help. You may also join the [new Discord Server](https://discord.gg/CGeKC6WQQb), but bear in mind that the response time tends to be longer. Online support is provided by volunteers — please provide clear information and sufficient context about the issue you are facing, and be mindful of people's time.

--- a/README_PublicCloud.md
+++ b/README_PublicCloud.md
@@ -1,0 +1,12 @@
+# Public Cloud Instructions
+
+Hosting the the public cloud is a great option if you are looking for a highly
+scalable and reliable solution.
+
+## :small_orange_diamond: AWS
+
+[Superalgos-Iac](https://github.com/khultman/Superalgos-IaC) is a terraform project
+with the goal of making it easy to deploy Superalgos to AWS. As of Dec. 2022 this
+project is still in development and is not yet ready for production use; however,
+it provides a documented design that could be used to deploy Superalgos to AWS.
+

--- a/README_PublicCloud.md
+++ b/README_PublicCloud.md
@@ -3,6 +3,10 @@
 Hosting the the public cloud is a great option if you are looking for a highly
 scalable and reliable solution.
 
+While Superalgos does not officially support any public cloud providers, there
+are community projects that have been created to make it easy to deploy Superalgos
+into the cloud. This page is a list of those projects.
+
 ## :small_orange_diamond: AWS
 
 [Superalgos-Iac](https://github.com/khultman/Superalgos-IaC) is a terraform project


### PR DESCRIPTION
Documentation for public cloud installation.
Original ticket: [Documentation for installing Superalgos in the Cloud and proper security practices #1541](https://github.com/Superalgos/Superalgos/issues/1541)

This adds light-weight documentation and a reference to the [Superalgos-IaC](https://github.com/khultman/Superalgos-IaC) project in development.

