### PR TITLE
Feature/credentials extraction

### DIFF
--- a/.tests/Projects/Foundations/PL/Utilities/CredentialsFunctions.test.js
+++ b/.tests/Projects/Foundations/PL/Utilities/CredentialsFunctions.test.js
@@ -1,0 +1,493 @@
+const project = 'Foundations'
+const credentialsFunctions = require('../../../../../Projects/Foundations/PL/Utilities/CredentialsFunctions')
+
+beforeEach(() => {
+    global.SA = {
+        nodeModules: {
+            fs: {
+                existsSync: undefined,
+                readFileSync: undefined,
+                writeFileSync: undefined
+            },
+            path: require('path')
+        }
+    }
+    
+    global.env = {
+        PATH_TO_SECRETS: './'
+    }
+})
+
+describe('loadExchangesCredentials()', () => {
+    it('should find existing credentials and load into payload', () => {
+        const codeName = 'testCode'
+        const secret = 'testSecret'
+
+        SA.nodeModules.fs.existsSync = jest.fn((_) => true)
+        SA.nodeModules.fs.readFileSync = jest.fn((_) => JSON.stringify([{
+            type: 'exchange',
+            key: codeName,
+            value: secret
+        }, {
+            type: 'exchange',
+            key: 'other',
+            value: 'other'
+        }, {
+            type: 'github',
+            key: codeName,
+            value: secret
+        }]))
+
+        const payload = {
+            rootNodes: [{
+                project,
+                type: 'Crypto Ecosystem',
+                cryptoExchanges: [{
+                    exchanges: [{
+                        exchangeAccounts: {
+                            userAccounts: [{
+                                userKeys: {
+                                    keys: [{
+                                        config: JSON.stringify({ codeName, secret: '' })
+                                    }]
+                                }
+                            }]
+                        }
+                    }]
+                }]
+            }]
+        }
+
+        const result = credentialsFunctions.newFoundationsUtilitiesCredentials().loadExchangesCredentials(payload)
+
+        expect(result.rootNodes[0].cryptoExchanges[0].exchanges[0].exchangeAccounts.userAccounts[0].userKeys.keys[0].config).toBeDefined()
+        const resultConfig = JSON.parse(result.rootNodes[0].cryptoExchanges[0].exchanges[0].exchangeAccounts.userAccounts[0].userKeys.keys[0].config)
+        expect(resultConfig.codeName).toBe(codeName)
+        expect(resultConfig.secret).toBe(secret)
+    })
+    it('should not update payload when credentials do not exist', () => {
+        const codeName = 'testCode'
+        const secret = 'testSecret'
+
+        SA.nodeModules.fs.existsSync = jest.fn((_) => true)
+        SA.nodeModules.fs.readFileSync = jest.fn((_) => JSON.stringify([{
+            type: 'exchange',
+            key: 'other',
+            value: 'other'
+        }, {
+            type: 'github',
+            key: codeName,
+            value: secret
+        }]))
+
+        const payload = {
+            rootNodes: [{
+                project,
+                type: 'Crypto Ecosystem',
+                cryptoExchanges: [{
+                    exchanges: [{
+                        exchangeAccounts: {
+                            userAccounts: [{
+                                userKeys: {
+                                    keys: [{
+                                        config: JSON.stringify({ codeName, secret: '' })
+                                    }]
+                                }
+                            }]
+                        }
+                    }]
+                }]
+            }]
+        }
+
+        const result = credentialsFunctions.newFoundationsUtilitiesCredentials().loadExchangesCredentials(payload)
+
+        expect(result.rootNodes[0].cryptoExchanges[0].exchanges[0].exchangeAccounts.userAccounts[0].userKeys.keys[0].config).toBeDefined()
+        const resultConfig = JSON.parse(result.rootNodes[0].cryptoExchanges[0].exchanges[0].exchangeAccounts.userAccounts[0].userKeys.keys[0].config)
+        expect(resultConfig.codeName).toBe(codeName)
+        expect(resultConfig.secret).toBe('')
+    })
+    it('should not update payload when credentials do not exist and will create credentials file', () => {
+        const codeName = 'testCode'
+
+        SA.nodeModules.fs.existsSync = jest.fn((_) => false)
+        SA.nodeModules.fs.writeFileSync = jest.fn()
+        SA.nodeModules.fs.readFileSync = jest.fn((_) => JSON.stringify([]))
+
+        const payload = {
+            rootNodes: [{
+                project,
+                type: 'Crypto Ecosystem',
+                cryptoExchanges: [{
+                    exchanges: [{
+                        exchangeAccounts: {
+                            userAccounts: [{
+                                userKeys: {
+                                    keys: [{
+                                        config: JSON.stringify({ codeName, secret: '' })
+                                    }]
+                                }
+                            }]
+                        }
+                    }]
+                }]
+            }]
+        }
+
+        const result = credentialsFunctions.newFoundationsUtilitiesCredentials().loadExchangesCredentials(payload)
+
+        expect(result.rootNodes[0].cryptoExchanges[0].exchanges[0].exchangeAccounts.userAccounts[0].userKeys.keys[0].config).toBeDefined()
+        const resultConfig = JSON.parse(result.rootNodes[0].cryptoExchanges[0].exchanges[0].exchangeAccounts.userAccounts[0].userKeys.keys[0].config)
+        expect(resultConfig.codeName).toBe(codeName)
+        expect(resultConfig.secret).toBe('')
+        expect(SA.nodeModules.fs.writeFileSync.mock.calls.length).toBe(1)
+    })
+})
+
+describe('loadGithubCredentials()', () => {
+    it('should find existing credentials and load into payload', () => {
+        const username = 'testCode'
+        const secret = 'testSecret'
+
+        SA.nodeModules.fs.existsSync = jest.fn((_) => true)
+        SA.nodeModules.fs.readFileSync = jest.fn((_) => JSON.stringify([{
+            type: 'exchange',
+            key: username,
+            value: secret
+        }, {
+            type: 'exchange',
+            key: 'other',
+            value: 'other'
+        }, {
+            type: 'github',
+            key: username,
+            value: secret
+        }]))
+
+        const payload = {
+            rootNodes: [{
+                project,
+                type: 'APIs',
+                githubAPI: {
+                    config: JSON.stringify({ username, token: '' })
+                }
+            }]
+        }
+
+        const result = credentialsFunctions.newFoundationsUtilitiesCredentials().loadGithubCredentials(payload)
+
+        expect(result.rootNodes[0].githubAPI.config).toBeDefined()
+        const resultConfig = JSON.parse(result.rootNodes[0].githubAPI.config)
+        expect(resultConfig.username).toBe(username)
+        expect(resultConfig.token).toBe(secret)
+    })
+    it('should not update payload when credentials do not exist', () => {
+        const username = 'testCode'
+        const secret = 'testSecret'
+
+        SA.nodeModules.fs.existsSync = jest.fn((_) => true)
+        SA.nodeModules.fs.readFileSync = jest.fn((_) => JSON.stringify([{
+            type: 'github',
+            key: 'other',
+            value: 'other'
+        }, {
+            type: 'exchange',
+            key: username,
+            value: secret
+        }]))
+
+        const payload = {
+            rootNodes: [{
+                project,
+                type: 'APIs',
+                githubAPI: {
+                    config: JSON.stringify({ username, token: '' })
+                }
+            }]
+        }
+
+        const result = credentialsFunctions.newFoundationsUtilitiesCredentials().loadGithubCredentials(payload)
+
+        expect(result.rootNodes[0].githubAPI.config).toBeDefined()
+        const resultConfig = JSON.parse(result.rootNodes[0].githubAPI.config)
+        expect(resultConfig.username).toBe(username)
+        expect(resultConfig.token).toBe('')
+    })
+    it('should not update payload when credentials do not exist and will create credentials file', () => {
+        const username = 'testCode'
+
+        SA.nodeModules.fs.existsSync = jest.fn((_) => false)
+        SA.nodeModules.fs.writeFileSync = jest.fn()
+        SA.nodeModules.fs.readFileSync = jest.fn((_) => JSON.stringify([]))
+
+        const payload = {
+            rootNodes: [{
+                project,
+                type: 'APIs',
+                githubAPI: {
+                    config: JSON.stringify({ username, token: '' })
+                }
+            }]
+        }
+
+        const result = credentialsFunctions.newFoundationsUtilitiesCredentials().loadGithubCredentials(payload)
+
+        expect(result.rootNodes[0].githubAPI.config).toBeDefined()
+        const resultConfig = JSON.parse(result.rootNodes[0].githubAPI.config)
+        expect(resultConfig.username).toBe(username)
+        expect(resultConfig.token).toBe('')
+        expect(SA.nodeModules.fs.writeFileSync.mock.calls.length).toBe(1)
+    })
+})
+
+describe('storeExchangesCredentials()', () => {
+    it('should find existing credentials and update from payload', () => {
+        const codeName = 'testCode'
+        const secret = 'testSecret'
+
+        let fileResult = []
+
+        SA.nodeModules.fs.existsSync = jest.fn((_) => true)
+        SA.nodeModules.fs.writeFileSync = jest.fn((_, contents) => fileResult = JSON.parse(contents))
+        SA.nodeModules.fs.readFileSync = jest.fn((_) => JSON.stringify([{
+            type: 'exchange',
+            key: codeName,
+            value: 'abc'
+        }, {
+            type: 'exchange',
+            key: 'other',
+            value: 'other'
+        }, {
+            type: 'github',
+            key: codeName,
+            value: secret
+        }]))
+
+        const payload = {
+            rootNodes: [{
+                project,
+                type: 'Crypto Ecosystem',
+                cryptoExchanges: [{
+                    exchanges: [{
+                        exchangeAccounts: {
+                            userAccounts: [{
+                                userKeys: {
+                                    keys: [{
+                                        config: JSON.stringify({ codeName, secret })
+                                    }]
+                                }
+                            }]
+                        }
+                    }]
+                }]
+            }]
+        }
+
+        const result = credentialsFunctions.newFoundationsUtilitiesCredentials().storeExchangesCredentials(payload)
+
+        expect(result.rootNodes[0].cryptoExchanges[0].exchanges[0].exchangeAccounts.userAccounts[0].userKeys.keys[0].config).toBeDefined()
+        const resultConfig = JSON.parse(result.rootNodes[0].cryptoExchanges[0].exchanges[0].exchangeAccounts.userAccounts[0].userKeys.keys[0].config)
+        expect(resultConfig.codeName).toBe(codeName)
+        expect(resultConfig.secret).toBe('')
+        expect(fileResult.length).toBe(3)
+        expect(fileResult.filter(x => x.type == 'exchange' && x.key == codeName && x.value == secret).length).toBe(1)
+    })
+    it('should add credentials when credentials do not exist', () => {
+        const codeName = 'testCode'
+        const secret = 'testSecret'
+
+        let fileResult = []
+
+        SA.nodeModules.fs.existsSync = jest.fn((_) => true)
+        SA.nodeModules.fs.writeFileSync = jest.fn((_, contents) => fileResult = JSON.parse(contents))
+        SA.nodeModules.fs.readFileSync = jest.fn((_) => JSON.stringify([{
+            type: 'exchange',
+            key: 'other',
+            value: 'other'
+        }, {
+            type: 'github',
+            key: codeName,
+            value: secret
+        }]))
+
+        const payload = {
+            rootNodes: [{
+                project,
+                type: 'Crypto Ecosystem',
+                cryptoExchanges: [{
+                    exchanges: [{
+                        exchangeAccounts: {
+                            userAccounts: [{
+                                userKeys: {
+                                    keys: [{
+                                        config: JSON.stringify({ codeName, secret })
+                                    }]
+                                }
+                            }]
+                        }
+                    }]
+                }]
+            }]
+        }
+
+        const result = credentialsFunctions.newFoundationsUtilitiesCredentials().storeExchangesCredentials(payload)
+
+        expect(result.rootNodes[0].cryptoExchanges[0].exchanges[0].exchangeAccounts.userAccounts[0].userKeys.keys[0].config).toBeDefined()
+        const resultConfig = JSON.parse(result.rootNodes[0].cryptoExchanges[0].exchanges[0].exchangeAccounts.userAccounts[0].userKeys.keys[0].config)
+        expect(resultConfig.codeName).toBe(codeName)
+        expect(resultConfig.secret).toBe('')
+        expect(fileResult.length).toBe(3)
+        expect(fileResult.filter(x => x.type == 'exchange' && x.key == codeName && x.value == secret).length).toBe(1)
+    })
+    it('should add credentials when none do not exist and will create credentials file', () => {
+        const codeName = 'testCode'
+        const secret = 'testSecret'
+
+        let fileResult = []
+
+        SA.nodeModules.fs.existsSync = jest.fn((_) => false)
+        SA.nodeModules.fs.writeFileSync = jest.fn((_, contents) => fileResult = JSON.parse(contents))
+        SA.nodeModules.fs.readFileSync = jest.fn((_) => JSON.stringify([]))
+
+        const payload = {
+            rootNodes: [{
+                project,
+                type: 'Crypto Ecosystem',
+                cryptoExchanges: [{
+                    exchanges: [{
+                        exchangeAccounts: {
+                            userAccounts: [{
+                                userKeys: {
+                                    keys: [{
+                                        config: JSON.stringify({ codeName, secret })
+                                    }]
+                                }
+                            }]
+                        }
+                    }]
+                }]
+            }]
+        }
+
+        const result = credentialsFunctions.newFoundationsUtilitiesCredentials().storeExchangesCredentials(payload)
+
+        expect(result.rootNodes[0].cryptoExchanges[0].exchanges[0].exchangeAccounts.userAccounts[0].userKeys.keys[0].config).toBeDefined()
+        const resultConfig = JSON.parse(result.rootNodes[0].cryptoExchanges[0].exchanges[0].exchangeAccounts.userAccounts[0].userKeys.keys[0].config)
+        expect(resultConfig.codeName).toBe(codeName)
+        expect(resultConfig.secret).toBe('')
+        expect(SA.nodeModules.fs.writeFileSync.mock.calls.length).toBe(2)
+        expect(fileResult.length).toBe(1)
+        expect(fileResult.filter(x => x.type == 'exchange' && x.key == codeName && x.value == secret).length).toBe(1)
+    })
+})
+
+describe('storeGithubCredentials()', () => {
+    it('should find existing credentials and update from payload', () => {
+        const username = 'testCode'
+        const secret = 'testSecret'
+
+        let fileResult = []
+
+        SA.nodeModules.fs.existsSync = jest.fn((_) => true)
+        SA.nodeModules.fs.writeFileSync = jest.fn((_, contents) => fileResult = JSON.parse(contents))
+        SA.nodeModules.fs.readFileSync = jest.fn((_) => JSON.stringify([{
+            type: 'exchange',
+            key: username,
+            value: secret
+        }, {
+            type: 'exchange',
+            key: 'other',
+            value: 'other'
+        }, {
+            type: 'github',
+            key: username,
+            value: 'abc'
+        }]))
+
+        const payload = {
+            rootNodes: [{
+                project,
+                type: 'APIs',
+                githubAPI: {
+                    config: JSON.stringify({ username, token: secret })
+                }
+            }]
+        }
+
+        const result = credentialsFunctions.newFoundationsUtilitiesCredentials().storeGithubCredentials(payload)
+
+        expect(result.rootNodes[0].githubAPI.config).toBeDefined()
+        const resultConfig = JSON.parse(result.rootNodes[0].githubAPI.config)
+        expect(resultConfig.username).toBe(username)
+        expect(resultConfig.token).toBe('')
+        expect(fileResult.length).toBe(3)
+        expect(fileResult.filter(x => x.type == 'github' && x.key == username && x.value == secret).length).toBe(1)
+    })
+    it('should add credentials when credentials do not exist', () => {
+        const username = 'testCode'
+        const secret = 'testSecret'
+
+        let fileResult = []
+
+        SA.nodeModules.fs.existsSync = jest.fn((_) => true)
+        SA.nodeModules.fs.writeFileSync = jest.fn((_, contents) => fileResult = JSON.parse(contents))
+        SA.nodeModules.fs.readFileSync = jest.fn((_) => JSON.stringify([{
+            type: 'github',
+            key: 'other',
+            value: 'other'
+        }, {
+            type: 'exchange',
+            key: username,
+            value: secret
+        }]))
+
+        const payload = {
+            rootNodes: [{
+                project,
+                type: 'APIs',
+                githubAPI: {
+                    config: JSON.stringify({ username, token: secret })
+                }
+            }]
+        }
+
+        const result = credentialsFunctions.newFoundationsUtilitiesCredentials().storeGithubCredentials(payload)
+
+        expect(result.rootNodes[0].githubAPI.config).toBeDefined()
+        const resultConfig = JSON.parse(result.rootNodes[0].githubAPI.config)
+        expect(resultConfig.username).toBe(username)
+        expect(resultConfig.token).toBe('')
+        expect(fileResult.length).toBe(3)
+        expect(fileResult.filter(x => x.type == 'github' && x.key == username && x.value == secret).length).toBe(1)
+    })
+    it('should add credentials when none do not exist and will create credentials file', () => {
+        const username = 'testCode'
+        const secret = 'testSecret'
+
+        let fileResult = []
+
+        SA.nodeModules.fs.existsSync = jest.fn((_) => false)
+        SA.nodeModules.fs.writeFileSync = jest.fn((_, contents) => fileResult = JSON.parse(contents))
+        SA.nodeModules.fs.readFileSync = jest.fn((_) => JSON.stringify([]))
+
+        const payload = {
+            rootNodes: [{
+                project,
+                type: 'APIs',
+                githubAPI: {
+                    config: JSON.stringify({ username, token: secret })
+                }
+            }]
+        }
+
+        const result = credentialsFunctions.newFoundationsUtilitiesCredentials().storeGithubCredentials(payload)
+
+        expect(result.rootNodes[0].githubAPI.config).toBeDefined()
+        const resultConfig = JSON.parse(result.rootNodes[0].githubAPI.config)
+        expect(resultConfig.username).toBe(username)
+        expect(resultConfig.token).toBe('')
+        expect(SA.nodeModules.fs.writeFileSync.mock.calls.length).toBe(2)
+        expect(fileResult.length).toBe(1)
+        expect(fileResult.filter(x => x.type == 'github' && x.key == username && x.value == secret).length).toBe(1)
+    })
+})

--- a/Platform/Client/Http-Routes/load-my-workspace.js
+++ b/Platform/Client/Http-Routes/load-my-workspace.js
@@ -11,6 +11,30 @@ exports.newLoadMyWorkspaceRoute = function newLoadMyWorkspaceRoute() {
         let requestPath = requestPathAndParameters[0].split('/')
         let fileName = unescape(requestPath[2])
         let filePath = global.env.PATH_TO_MY_WORKSPACES + '/' + fileName + '.json'
-        SA.projects.foundations.utilities.httpResponses.respondWithFile(filePath, httpResponse)
+
+        respondWithFile(filePath, httpResponse)
+    }
+    
+    function respondWithFile(fileName, httpResponse) {
+        if (fileName.indexOf('undefined') > 0) {
+            SA.logger.warn('respondWithFile -> Received httpRequest for undefined file. ')
+            SA.projects.foundations.utilities.httpResponses.respondWithContent(undefined, httpResponse)
+        } else {
+            try {
+                SA.nodeModules.fs.readFile(fileName, onFileRead)
+                
+                function onFileRead(err, file) {
+                    if (!err) {
+                        let workspace = PL.projects.foundations.utilities.credentials.loadExchangesCredentials(PL.projects.foundations.utilities.credentials.loadGithubCredentials(JSON.parse(file.toString())))
+                        SA.projects.foundations.utilities.httpResponses.respondWithContent(JSON.stringify(workspace), httpResponse)
+                    } else {
+                        //SA.logger.info('File requested not found: ' + fileName)
+                        SA.projects.foundations.utilities.httpResponses.respondWithContent(undefined, httpResponse)
+                    }
+                }
+            } catch (err) {
+                SA.projects.foundations.utilities.httpResponses.respondWithEmptyArray(httpResponse)
+            }
+        }
     }
 }

--- a/Platform/Client/Http-Routes/save-workspace.js
+++ b/Platform/Client/Http-Routes/save-workspace.js
@@ -20,7 +20,7 @@ exports.newSaveWorkspaceRoute = function newSaveWorkspaceRoute() {
                 let fileName = unescape(requestPath[2])
                 let filePath = global.env.PATH_TO_MY_WORKSPACES + '/' + fileName + '.json'
                 
-                let workspace = JSON.parse(body)
+                let workspace = PL.projects.foundations.utilities.credentials.storeExchangesCredentials(PL.projects.foundations.utilities.credentials.storeGithubCredentials(JSON.parse(body)))
                 let fileContent = JSON.stringify(workspace, undefined, 4)
                 let fs = SA.nodeModules.fs
                 let dir = global.env.PATH_TO_MY_WORKSPACES;

--- a/Projects/Foundations/PL/Utilities/CredentialsFunctions.js
+++ b/Projects/Foundations/PL/Utilities/CredentialsFunctions.js
@@ -1,0 +1,223 @@
+/**
+ * @typedef {{
+ *   config: string
+ * }} Config
+ * 
+ * @typedef {{
+ *   keys: Config[]
+ * }} UserKey
+ * 
+ * @typedef {{
+ *   userKeys: UserKey
+ * }} UserAccount
+ * 
+ * @typedef {{
+ *   exchangeAccounts: {
+ *     userAccounts: UserAccount[]
+ *   }
+ * }} Exchange
+ * 
+ * @typedef {{
+ *   exchanges: Exchange[]
+ * }} CryptoExchange
+ * 
+ * @typedef {{
+ *   rootNodes: {
+ *     project: string,
+ *     type: string,
+ *     githubAPI: Config|undefined,
+ *     cryptoExchanges: CryptoExchange[]
+ *   }[]
+ * }} Payload
+ * 
+ * @typedef {{
+ *   type: 'github'|'exchange',
+ *   key: string,
+ *   value: string
+ * }} Credentials
+*/
+
+exports.newFoundationsUtilitiesCredentials = function newFoundationsUtilitiesCredentials() {
+    let thisObject = {
+        loadExchangesCredentials: loadExchangesCredentials,
+        loadGithubCredentials: loadGithubCredentials,
+        storeExchangesCredentials: storeExchangesCredentials,
+        storeGithubCredentials: storeGithubCredentials,
+    }
+
+    const githubType = 'github'
+    const exchangeType = 'exchange'
+
+    return thisObject
+
+    /**
+     * @param {Payload} payload 
+     * @returns {Payload}
+     */
+    function loadGithubCredentials(payload) {
+        const node = payload.rootNodes.find(node => node.project == 'Foundations' && node.type == 'APIs' && node.githubAPI !== undefined)
+        if (node !== undefined) {
+            const config = JSON.parse(node.githubAPI.config)
+            if (config.username !== undefined && config.username.length > 0) {
+                const credentials = readCredentialsFile()
+                const match = credentials.find(creds => creds.type == githubType && creds.key == config.username)
+                if (match !== undefined) {
+                    config.token = match.value
+                }
+            }
+            node.githubAPI.config = JSON.stringify(config, null, 4)
+        }
+        return payload
+    }
+
+    /**
+     * @param {Payload} payload 
+     * @returns {Payload}
+     */
+    function loadExchangesCredentials(payload) {
+        const node = payload.rootNodes.find(node => node.project == 'Foundations' && node.type == 'Crypto Ecosystem' && node.cryptoExchanges !== undefined && node.cryptoExchanges.length > 0)
+        if (node !== undefined) {
+            iterateCryptoExchanges(node.cryptoExchanges, iterateUserKeys)
+        }
+        return payload
+
+        /**
+         * @param {Config[]} userKeys 
+         */
+        function iterateUserKeys(userKeys) {
+            for (let i = 0; i < userKeys.length; i++) {
+                const config = JSON.parse(userKeys[i].config)
+                if (config.codeName !== undefined && config.codeName.length > 0) {
+                    const credentials = readCredentialsFile()
+                    const match = credentials.find(creds => creds.type == exchangeType && creds.key == config.codeName)
+                    if (match !== undefined) {
+                        config.secret = match.value
+                    }
+                }
+                userKeys[i].config = JSON.stringify(config, null, 4)
+            }
+        }
+    }
+
+    /**
+     * @param {Payload} payload 
+     * @returns {Payload}
+     */
+    function storeGithubCredentials(payload) {
+        const node = payload.rootNodes.find(node => node.project == 'Foundations' && node.type == 'APIs' && node.githubAPI !== undefined)
+        if (node !== undefined) {
+            const config = JSON.parse(node.githubAPI.config)
+            if (config.username !== undefined && config.username.length > 0 && config.token !== undefined && config.token.length > 0) {
+                const credentials = readCredentialsFile()
+                const matchIdx = credentials.findIndex(creds => creds.type == githubType && creds.key == config.username)
+                if (matchIdx > -1) {
+                    credentials[matchIdx].value = config.token
+                }
+                else {
+                    credentials.push({
+                        type: githubType,
+                        key: config.username,
+                        value: config.token
+                    })
+                }
+                writeCredentialsFile(credentials)
+            }
+            config.token = ''
+            node.githubAPI.config = JSON.stringify(config, null, 4)
+        }
+        return payload
+    }
+
+    /**
+     * @param {Payload} payload 
+     * @returns {Payload}
+    */
+    function storeExchangesCredentials(payload) {
+        const node = payload.rootNodes.find(node => node.project == 'Foundations' && node.type == 'Crypto Ecosystem' && node.cryptoExchanges !== undefined && node.cryptoExchanges.length > 0)
+        if (node !== undefined) {
+            iterateCryptoExchanges(node.cryptoExchanges, iterateUserKeys)
+        }
+        return payload
+
+        /**
+         * @param {Config[]} userKeys 
+         */
+        function iterateUserKeys(userKeys) {
+            for (let i = 0; i < userKeys.length; i++) {
+                const config = JSON.parse(userKeys[i].config)
+                if (config.codeName !== undefined && config.codeName.length > 0 && config.secret !== undefined && config.secret.length > 0) {
+                    const credentials = readCredentialsFile()
+                    const matchIdx = credentials.findIndex(creds => creds.type == exchangeType && creds.key == config.codeName)
+                    if (matchIdx > -1) {
+                        credentials[matchIdx].value = config.secret
+                    }
+                    else {
+                        credentials.push({
+                            type: exchangeType,
+                            key: config.codeName,
+                            value: config.secret
+                        })
+                    }
+                    writeCredentialsFile(credentials)
+                }
+                config.secret = ''
+                userKeys[i].config = JSON.stringify(config, null, 4)
+            }
+        }
+    }
+
+    /**
+     * @param {CryptoExchange[]} cryptoExchanges 
+     * @param {(userKeys: Config[]) => void} keyFunction
+     */
+    function iterateCryptoExchanges(cryptoExchanges, keyFunction) {
+        for (let i = 0; i < cryptoExchanges.length; i++) {
+            iterateExchanges(cryptoExchanges[i].exchanges, keyFunction)
+        }
+    }
+
+    /**
+     * @param {Exchange[]} exchanges 
+     */
+    function iterateExchanges(exchanges, keyFunction) {
+        for (let i = 0; i < exchanges.length; i++) {
+            iterateUserAccounts(exchanges[i].exchangeAccounts.userAccounts, keyFunction)
+        }
+    }
+
+    /**
+     * @param {UserAccount[]} userAccounts 
+     */
+    function iterateUserAccounts(userAccounts, keyFunction) {
+        for (let i = 0; i < userAccounts.length; i++) {
+            keyFunction(userAccounts[i].userKeys.keys)
+        }
+    }
+
+    /**
+     * @returns {Credentials[]}
+     */
+    function readCredentialsFile() {
+        const filePath = secretsFilePath()
+        if (!SA.nodeModules.fs.existsSync(filePath)) {
+            writeCredentialsFile([])
+        }
+
+        const secretsFileContent = SA.nodeModules.fs.readFileSync(filePath)
+        return JSON.parse(secretsFileContent)
+    }
+
+    /**
+     * @param {Credentials[]} credentials 
+     */
+    function writeCredentialsFile(credentials) {
+        SA.nodeModules.fs.writeFileSync(secretsFilePath(), JSON.stringify(credentials, null, 4))
+    }
+
+    /**
+     * @returns {string}
+     */
+    function secretsFilePath() {
+        return SA.nodeModules.path.join(global.env.PATH_TO_SECRETS, 'workspace-credentials.json')
+    }
+}

--- a/Projects/ProjectsSchema.json
+++ b/Projects/ProjectsSchema.json
@@ -957,7 +957,14 @@
             ]
         },
         "PL": {
-            "utilities": []
+            "utilities": [
+                {
+                    "name": "Credentials Functions",
+                    "propertyName": "credentials",
+                    "functionName": "newFoundationsUtilitiesCredentials",
+                    "fileName": "CredentialsFunctions.js"
+                }
+            ]
         },
         "SA": {
             "globals": [


### PR DESCRIPTION
Added a means to extract credentials from My-Workspaces so workspaces can be stored, shared and reused without needing to check for leaked credentials.

Secret values are removed from the workspace json before saving, keys/names are still stored and used as a reference to match with api values.

A new file is created in ./My-Secrets/workspace-credentials.json which uses a generic array of objects to store values:

```json
[
  { 
    "type": "github"|"exchange",
    "key: "api_key"
    "value: "api_secret"
  }
]
```

This also now means that credentials can be shared across workspaces more easily and it will mean if you need to update and API key, for example, your github token it will get updated for all workspaces. One concern is if you have many API secrets for a single key as could be the case for github.
