### PR TITLE
Documentation correction for hotkey

### DIFF
--- a/Projects/Foundations/Schemas/Docs-Topics/H/How/How-To/how-to-002-establish-and-remove-references.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/H/How/How-To/how-to-002-establish-and-remove-references.json
@@ -112,26 +112,26 @@
         },
         {
             "style": "Success",
-            "text": "You may toggle these grey lines on and off using: Ctrl + Shift + Alt + Key-R",
+            "text": "You may toggle these grey lines on and off using: Ctrl + Shift + Key-R",
             "translations": [
                 {
                     "language": "RU",
-                    "text": "Вы можете включать и выключать эти серые линии, используя: Ctrl + Shift + Alt + Клавиша-R",
+                    "text": "Вы можете включать и выключать эти серые линии, используя: Ctrl + Shift + Клавиша-R",
                     "updated": 1638346885836
                 },
                 {
                     "language": "TR",
-                    "text": "Bu gri çizgileri şu tuş kombinasyonunu kullanarak açıp kapatabilirsiniz: Ctrl + Shift + Alt + Key-R",
+                    "text": "Bu gri çizgileri şu tuş kombinasyonunu kullanarak açıp kapatabilirsiniz: Ctrl + Shift + Key-R",
                     "updated": 1639562086642
                 },
                 {
                     "language": "EL",
-                    "text": "Μπορείτε να ενεργοποιήσετε και να απενεργοποιήσετε αυτές τις γκρίζες γραμμές χρησιμοποιώντας: Ctrl + Shift + Alt + Key-R",
+                    "text": "Μπορείτε να ενεργοποιήσετε και να απενεργοποιήσετε αυτές τις γκρίζες γραμμές χρησιμοποιώντας: Ctrl + Shift + Key-R",
                     "updated": 1641831690145
                 },
                 {
                     "language": "DE",
-                    "text": "Sie können diese grauen Linien ein- und ausschalten mit: Ctrl + Shift + Alt + Key-R",
+                    "text": "Sie können diese grauen Linien ein- und ausschalten mit: Ctrl + Shift + Key-R",
                     "updated": 1644783983928
                 }
             ]

--- a/Projects/Foundations/Schemas/Docs-Topics/I/Introduction/Introduction/introduction-007-references.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/I/Introduction/Introduction/introduction-007-references.json
@@ -431,7 +431,7 @@
         },
         {
             "style": "Text",
-            "text": "Ctrl + Shift + Alt + Key-R"
+            "text": "Ctrl + Shift + Key-R"
         },
         {
             "style": "Note",


### PR DESCRIPTION
Tiny correction for something I noticed when going through the Basic Education tutorial. The previous hotkey no longer seems to be valid, and a few pages later it displays the correct hotkey (CTRL + SHIFT + KEY-R) which does in-fact enable the grey-dotted internal reference lines