### PR TITLE
Governance: Refactoring Power allocation by amount, optimizations

### DIFF
--- a/Projects/Governance/SA/Function-Libraries/ProfileTokenPower.js
+++ b/Projects/Governance/SA/Function-Libraries/ProfileTokenPower.js
@@ -190,8 +190,17 @@ exports.newGovernanceFunctionLibraryProfileTokenPower = function newGovernanceFu
             is going to be switched between all nodes. The first pass is about
             scanning all sibling nodes to see which ones have a percentage defined
             at their config, and check that all percentages don't add more than 100.
+
+            We will also check for nodes having absolute amounts of token power configured
+            and verify if the total of defined amounts is below the available token power.
+            If not, we will reduce the token power to be allocated equally by the share
+            of the configured amount exceeding the available amount.
+
+            Token Power remaining after servicing nodes with a configured amount will be
+            distributed to nodes with a configured percentage or with no configuration.
             */
             let totalPercentage = 0
+            let totalAmount = 0
             let totalNodesWithoutPercentage = 0
             for (let i = 0; i < schemaDocument.childrenNodesProperties.length; i++) {
                 let property = schemaDocument.childrenNodesProperties[i]
@@ -203,9 +212,12 @@ exports.newGovernanceFunctionLibraryProfileTokenPower = function newGovernanceFu
                         if (childNode.type === "Delegation Program" && excludeDelegationProgram === true) { continue }
                         if (OPAQUE_NODES_TYPES.includes(childNode.type)) { continue }
 
-                        let percentage = getPercentage(childNode)
-                        if (percentage !== undefined && isNaN(percentage) !== true && percentage >= 0) {
-                            totalPercentage = totalPercentage + percentage
+                        let config = getTokenPowerRequest(childNode)
+
+                        if (config?.type === "amount" && config?.value >= 0) {
+                            totalAmount = totalAmount + config.value
+                        } else if (config?.type === "percentage" && config?.value >= 0) {
+                            totalPercentage = totalPercentage + config.value
                         } else {
                             totalNodesWithoutPercentage++
                         }
@@ -220,9 +232,12 @@ exports.newGovernanceFunctionLibraryProfileTokenPower = function newGovernanceFu
                                 if (childNode.type === "Delegation Program" && excludeDelegationProgram === true) { continue }
                                 if (OPAQUE_NODES_TYPES.includes(childNode.type)) { continue }
 
-                                let percentage = getPercentage(childNode)
-                                if (percentage !== undefined && isNaN(percentage) !== true && percentage >= 0) {
-                                    totalPercentage = totalPercentage + percentage
+                                let config = getTokenPowerRequest(childNode)
+
+                                if (config?.type === "amount" && config?.value >= 0) {
+                                    totalAmount = totalAmount + config.value
+                                } else if (config?.type === "percentage" && config?.value >= 0) {
+                                    totalPercentage = totalPercentage + config.value
                                 } else {
                                     totalNodesWithoutPercentage++
                                 }
@@ -239,6 +254,17 @@ exports.newGovernanceFunctionLibraryProfileTokenPower = function newGovernanceFu
             if (totalNodesWithoutPercentage > 0) {
                 defaultPercentage = (100 - totalPercentage) / totalNodesWithoutPercentage
             }
+                        
+            /* If configured Token Power amounts exceed the available Token Power, determine the share by which requests need to be reduced.
+            Store the Token Power remaining for distribution via percentages after all amount requests have been served in percentagePower. */
+            let percentagePower = 0
+            let amountShare = 1
+            if (totalAmount > tokenPower && totalAmount > 0) {
+                amountShare = tokenPower / totalAmount
+            } else {
+                percentagePower = tokenPower - totalAmount
+            }
+
             /*
             Here we do the actual distribution.
             */
@@ -252,13 +278,24 @@ exports.newGovernanceFunctionLibraryProfileTokenPower = function newGovernanceFu
                         if (childNode.type === "Delegation Program" && excludeDelegationProgram === true) { continue }
                         if (OPAQUE_NODES_TYPES.includes(childNode.type)) { continue }
 
-                        let percentage = getPercentage(childNode)
-                        if (percentage === undefined || isNaN(percentage)  || percentage < 0 === true) {
+                        let distributionAmount = 0
+                        let percentage = 0
+                        let config = getTokenPowerRequest(childNode)
+
+                        if (config?.type === "amount" && config?.value >= 0) {
+                            distributionAmount = config.value * amountShare
+                            percentage = "fixed"
+                        } else if (config?.type === "percentage" && config?.value >= 0) {
+                            distributionAmount = percentagePower * config.value / 100
+                            percentage = config.value
+                        } else {
+                            distributionAmount = percentagePower * defaultPercentage / 100
                             percentage = defaultPercentage
                         }
+
                         distributeTokenPower(
                             childNode,
-                            tokenPower * percentage / 100,
+                            distributionAmount,
                             percentage,
                             excludeDelegationProgram
                         )
@@ -273,13 +310,24 @@ exports.newGovernanceFunctionLibraryProfileTokenPower = function newGovernanceFu
                                 if (childNode.type === "Delegation Program" && excludeDelegationProgram === true) { continue }
                                 if (OPAQUE_NODES_TYPES.includes(childNode.type)) { continue }
 
-                                let percentage = getPercentage(childNode)
-                                if (percentage === undefined || isNaN(percentage)  || percentage < 0 === true) {
+                                let distributionAmount = 0
+                                let percentage = 0
+                                let config = getTokenPowerRequest(childNode)
+        
+                                if (config?.type === "amount" && config?.value >= 0) {
+                                    distributionAmount = config.value * amountShare
+                                    percentage = "fixed"
+                                } else if (config?.type === "percentage" && config?.value >= 0) {
+                                    distributionAmount = percentagePower * config.value / 100
+                                    percentage = config.value
+                                } else {
+                                    distributionAmount = percentagePower * defaultPercentage / 100
                                     percentage = defaultPercentage
                                 }
+
                                 distributeTokenPower(
                                     childNode,
-                                    tokenPower * percentage / 100,
+                                    distributionAmount,
                                     percentage,
                                     excludeDelegationProgram
                                 )
@@ -451,6 +499,7 @@ exports.newGovernanceFunctionLibraryProfileTokenPower = function newGovernanceFu
                     at their config, and check that all percentages don't add more than 100.
                     */
                     let totalPercentage = 0
+                    let totalAmount = 0
                     let totalNodesWithoutPercentage = 0
                     for (let i = 0; i < schemaDocument.childrenNodesProperties.length; i++) {
                         let property = schemaDocument.childrenNodesProperties[i]
@@ -460,9 +509,13 @@ exports.newGovernanceFunctionLibraryProfileTokenPower = function newGovernanceFu
                                 let childNode = node[property.name]
                                 if (childNode === undefined) { continue }
                                 if (childNode.type === 'Tokens Bonus') { continue }
-                                let percentage = getPercentage(childNode)
-                                if (percentage !== undefined && isNaN(percentage) !== true && percentage >= 0) {
-                                    totalPercentage = totalPercentage + percentage
+
+                                let config = getTokenPowerRequest(childNode)
+
+                                if (config?.type === "amount" && config?.value >= 0) {
+                                    totalAmount = totalAmount + config.value
+                                } else if (config?.type === "percentage" && config?.value >= 0) {
+                                    totalPercentage = totalPercentage + config.value
                                 } else {
                                     totalNodesWithoutPercentage++
                                 }
@@ -475,9 +528,13 @@ exports.newGovernanceFunctionLibraryProfileTokenPower = function newGovernanceFu
                                         let childNode = propertyArray[m]
                                         if (childNode === undefined) { continue }
                                         if (childNode.type === 'Tokens Bonus') { continue }
-                                        let percentage = getPercentage(childNode)
-                                        if (percentage !== undefined && isNaN(percentage) !== true && percentage >= 0) {
-                                            totalPercentage = totalPercentage + percentage
+                                        
+                                        let config = getTokenPowerRequest(childNode)
+
+                                        if (config?.type === "amount" && config?.value >= 0) {
+                                            totalAmount = totalAmount + config.value
+                                        } else if (config?.type === "percentage" && config?.value >= 0) {
+                                            totalPercentage = totalPercentage + config.value
                                         } else {
                                             totalNodesWithoutPercentage++
                                         }
@@ -494,6 +551,16 @@ exports.newGovernanceFunctionLibraryProfileTokenPower = function newGovernanceFu
                     if (totalNodesWithoutPercentage > 0) {
                         defaultPercentage = (100 - totalPercentage) / totalNodesWithoutPercentage
                     }
+                    /* If configured Token Power amounts exceed the available Token Power, determine the share by which requests need to be reduced.
+                    Store the Token Power remaining for distribution via percentages after all amount requests have been served in percentagePower. */
+                    let percentagePower = 0
+                    let amountShare = 1
+                    if (totalAmount > programPower && totalAmount > 0) {
+                        amountShare = programPower / totalAmount
+                    } else {
+                        percentagePower = programPower - totalAmount
+                    }
+                    
                     /*
                     Here we do the actual distribution.
                     */
@@ -505,14 +572,24 @@ exports.newGovernanceFunctionLibraryProfileTokenPower = function newGovernanceFu
                                 let childNode = node[property.name]
                                 if (childNode === undefined) { continue }
                                 if (childNode.type === 'Tokens Bonus') { continue }
-                                let percentage = getPercentage(childNode)
-                                if (percentage === undefined || isNaN(percentage)  || percentage < 0 === true) {
+                                let distributionAmount = 0
+                                let percentage = 0
+                                let config = getTokenPowerRequest(childNode)
+        
+                                if (config?.type === "amount" && config?.value >= 0) {
+                                    distributionAmount = config.value * amountShare
+                                    percentage = "fixed"
+                                } else if (config?.type === "percentage" && config?.value >= 0) {
+                                    distributionAmount = percentagePower * config.value / 100
+                                    percentage = config.value
+                                } else {
+                                    distributionAmount = percentagePower * defaultPercentage / 100
                                     percentage = defaultPercentage
                                 }
                                 distributeProgramPower(
                                     currentProgramNode, 
                                     childNode, 
-                                    programPower * percentage / 100, 
+                                    distributionAmount, 
                                     percentage,
                                     generation
                                     )
@@ -525,14 +602,22 @@ exports.newGovernanceFunctionLibraryProfileTokenPower = function newGovernanceFu
                                         let childNode = propertyArray[m]
                                         if (childNode === undefined) { continue }
                                         if (childNode.type === 'Tokens Bonus') { continue }
-                                        let percentage = getPercentage(childNode)
-                                        if (percentage === undefined || isNaN(percentage)  || percentage < 0 === true) {
+                                        let config = getTokenPowerRequest(childNode)
+        
+                                        if (config?.type === "amount" && config?.value >= 0) {
+                                            distributionAmount = config.value * amountShare
+                                            percentage = "fixed"
+                                        } else if (config?.type === "percentage" && config?.value >= 0) {
+                                            distributionAmount = percentagePower * config.value / 100
+                                            percentage = config.value
+                                        } else {
+                                            distributionAmount = percentagePower * defaultPercentage / 100
                                             percentage = defaultPercentage
                                         }
                                         distributeProgramPower(
                                             currentProgramNode, 
                                             childNode, 
-                                            programPower * percentage / 100, 
+                                            distributionAmount, 
                                             percentage,
                                             generation
                                             )
@@ -547,38 +632,37 @@ exports.newGovernanceFunctionLibraryProfileTokenPower = function newGovernanceFu
         }
     }
     
-    function getPercentage(node) {
-            if (node.config === undefined) { return }
+    function getTokenPowerRequest(node) {
+        if (node.config === undefined) { return }
+        let result = {}
+        let config = node.config
+        let amount = config.amount
+        let percentage = config.percentage
 
-            let config = node.config
-            let percentage = config.percentage
-            let amount = config.amount
-            let parentPower = node.parentNode.payload.tokenPower
+        if (percentage !== undefined && amount !== undefined) { return }
 
-            // Check that not both are defined
-            if (percentage !== undefined && amount !== undefined) {
-                return
-            }
-
-            // If only 'percentage' is defined, we return that number
-            else if (isFinite(percentage) && !isFinite(amount)) {
-                return percentage
-            }
-
-            // If only 'amount' is defined, we use calculate what percentage 'amount' is of the 'parentPower'.
-            else if (!isFinite(percentage) && isFinite(amount) && isFinite(parentPower)) {
-                percentage = (amount / parentPower) * 100
-
-                // If the 'amount' is greater than what is available at the parent node, we assume it is intended and is used as a "maximum power".
-                if (percentage > 100) {
-                    return 100
-                }
-                return percentage
-            }
-
-            // If user havn't defined any of the values in the config, we return 'undefined'
-            else {
-                return undefined
-            }
+        /* Node configuration requests an absolute amount of token power */
+        if (amount !== undefined) {
+            result.type = "amount"
+            /* We do not allow amounts smaller than 0 */
+            if (!isFinite(amount) || amount < 0) { return }
+            /* Check if the node already has token power and reduce the result accordingly */
+            if (node.payload.tokenPower !== undefined && isFinite(node.payload.tokenPower)) {
+                let neededTokenPower = amount - node.payload.tokenPower
+                if (neededTokenPower < 0) { neededTokenPower = 0}
+                result.value = neededTokenPower
+            } else {
+                result.value = amount
+            }           
+        /* Node configuration requests a percentage of available token power */
+        } else if (percentage !== undefined) {
+            result.type = "percentage"
+            /* We do not allow percentages smaller than 0 */
+            if (!isFinite(percentage) || percentage < 0) { return }
+            result.value = percentage
+        } else {
+            return
         }
+        return result
+    }
 }

--- a/Projects/Governance/SA/Function-Libraries/ProfileTokenPower.js
+++ b/Projects/Governance/SA/Function-Libraries/ProfileTokenPower.js
@@ -574,8 +574,7 @@ exports.newGovernanceFunctionLibraryProfileTokenPower = function newGovernanceFu
                                 if (childNode.type === 'Tokens Bonus') { continue }
                                 let distributionAmount = 0
                                 let percentage = 0
-                                let config = getTokenPowerRequest(childNode)
-        
+                                let config = getTokenPowerRequest(childNode)   
                                 if (config?.type === "amount" && config?.value >= 0) {
                                     distributionAmount = config.value * amountShare
                                     percentage = "fixed"
@@ -602,8 +601,9 @@ exports.newGovernanceFunctionLibraryProfileTokenPower = function newGovernanceFu
                                         let childNode = propertyArray[m]
                                         if (childNode === undefined) { continue }
                                         if (childNode.type === 'Tokens Bonus') { continue }
+                                        let distributionAmount = 0
+                                        let percentage = 0
                                         let config = getTokenPowerRequest(childNode)
-        
                                         if (config?.type === "amount" && config?.value >= 0) {
                                             distributionAmount = config.value * amountShare
                                             percentage = "fixed"

--- a/Projects/Governance/UI/Function-Libraries/ClaimsProgram.js
+++ b/Projects/Governance/UI/Function-Libraries/ClaimsProgram.js
@@ -214,14 +214,36 @@ function newGovernanceFunctionLibraryClaimsProgram() {
                     node.payload.referenceParent.payload.claimsProgram.count !== undefined &&
                     node.payload.referenceParent.payload.claimsProgram.votes !== undefined
                 ) {
-                    /*                    
-                        claimPowerToUse is the minimun between the Claim Power the user is assigning to 
-                        his claim, and the votes the claim have from other user profiles.
+                    /*
+                    Check if the user only wants to claim a specific share of a reward pool
                     */
-                    let claimPowerToUse = Math.min(
-                        programPower,
-                        node.payload.votingProgram.votes
-                    )
+                    let claimedShare = UI.projects.visualScripting.utilities.nodeConfig.loadConfigProperty(node.payload, 'claimedShare')
+                    let claimedShareTokens
+                    if (!isFinite(claimedShare) || claimedShare < 0) {
+                        claimedShare = undefined
+                    } else {
+                        claimedShareTokens = node.payload.referenceParent.payload.tokens * claimedShare / 100
+                    }
+                                                           
+                    /*                    
+                        claimPowerToUse is the minimum between the Claim Power the user is assigning to 
+                        his claim, the votes the claim has from other user profiles, and the maximum
+                        share of tokens the user wants to claim from a pool (if defined)
+                    */
+                    let claimPowerToUse = 0
+                    if (claimedShareTokens !== undefined) {
+                        claimPowerToUse = Math.min(
+                            programPower,
+                            node.payload.votingProgram.votes,
+                            claimedShareTokens
+                        )
+                    } else {
+                        claimPowerToUse = Math.min(
+                            programPower,
+                            node.payload.votingProgram.votes
+                        )
+                    }
+
                     /*
                     If the claimPowerToUse is bigger than the token reward, then we cap it at the
                     token reward. In this way a user can put more claim power than needed and get
@@ -266,6 +288,18 @@ function newGovernanceFunctionLibraryClaimsProgram() {
                         drawClaims(node)
                         drawProgramPower(node, programPower, percentage)
                     }
+                /* Remove status display if no claim will be allocated */
+                } else if (
+                    node.payload.votingProgram?.votes === undefined ||
+                    node.payload.votingProgram?.votes <= 0 ||
+                    node.payload.referenceParent?.payload?.votingProgram?.votes === undefined ||
+                    node.payload.referenceParent?.payload?.votingProgram?.votes <= 0 ||
+                    node.payload.referenceParent?.payload?.weight === undefined ||
+                    node.payload.referenceParent?.payload?.weight === 0 ||
+                    node.payload.referenceParent?.payload?.claimsProgram?.count === undefined ||
+                    node.payload.referenceParent?.payload?.claimsProgram?.votes === undefined
+                ) {
+                    node.payload.uiObject.resetStatus()
                 }
             } else {
                 if (node.type === 'Claims Program') {
@@ -286,6 +320,7 @@ function newGovernanceFunctionLibraryClaimsProgram() {
             at their config, and check that all percentages don't add more than 100.
             */
             let totalPercentage = 0
+            let totalAmount = 0
             let totalNodesWithoutPercentage = 0
             for (let i = 0; i < schemaDocument.childrenNodesProperties.length; i++) {
                 let property = schemaDocument.childrenNodesProperties[i]
@@ -294,12 +329,14 @@ function newGovernanceFunctionLibraryClaimsProgram() {
                         let childNode = node[property.name]
                         if (childNode === undefined) { continue }
                         if (childNode.type === "Tokens Awarded") { continue }
-                        let percentage = UI.projects.governance.utilities.nodeCalculations.percentage(childNode)
-                        if (percentage !== undefined && isNaN(percentage) !== true && percentage >= 0) {
-                            totalPercentage = totalPercentage + percentage
+                        let config = UI.projects.governance.utilities.nodeCalculations.getDistributionConfig(childNode, false)
+                        if (config?.type === "amount" && config?.value >= 0) {
+                            totalAmount = totalAmount + config.value
+                        } else if (config?.type === "percentage" && config?.value >= 0) {
+                            totalPercentage = totalPercentage + config.value
                         } else {
                             totalNodesWithoutPercentage++
-                        }
+                        }  
                     }
                         break
                     case 'array': {
@@ -309,9 +346,11 @@ function newGovernanceFunctionLibraryClaimsProgram() {
                                 let childNode = propertyArray[m]
                                 if (childNode === undefined) { continue }
                                 if (childNode.type === "Tokens Awarded") { continue }
-                                let percentage = UI.projects.governance.utilities.nodeCalculations.percentage(childNode)
-                                if (percentage !== undefined && isNaN(percentage) !== true && percentage >= 0) {
-                                    totalPercentage = totalPercentage + percentage
+                                let config = UI.projects.governance.utilities.nodeCalculations.getDistributionConfig(childNode, false)
+                                if (config?.type === "amount" && config?.value >= 0) {
+                                    totalAmount = totalAmount + config.value
+                                } else if (config?.type === "percentage" && config?.value >= 0) {
+                                    totalPercentage = totalPercentage + config.value
                                 } else {
                                     totalNodesWithoutPercentage++
                                 }
@@ -332,6 +371,17 @@ function newGovernanceFunctionLibraryClaimsProgram() {
             if (totalNodesWithoutPercentage > 0) {
                 defaultPercentage = (100 - totalPercentage) / totalNodesWithoutPercentage
             }
+            
+            /* If configured Token Power amounts exceed the available Token Power, determine the share by which requests need to be reduced.
+            Store the Token Power remaining for distribution via percentages after all amount requests have been served in percentagePower. */
+            let percentagePower = 0
+            let amountShare = 1
+            if (totalAmount > programPower && totalAmount > 0) {
+                amountShare = programPower / totalAmount
+            } else {
+                percentagePower = programPower - totalAmount
+            }
+
             for (let i = 0; i < schemaDocument.childrenNodesProperties.length; i++) {
                 let property = schemaDocument.childrenNodesProperties[i]
                 switch (property.type) {
@@ -339,11 +389,20 @@ function newGovernanceFunctionLibraryClaimsProgram() {
                         let childNode = node[property.name]
                         if (childNode === undefined) { continue }
                         if (childNode.type === "Tokens Awarded") { continue }
-                        let percentage = UI.projects.governance.utilities.nodeCalculations.percentage(childNode)
-                        if (percentage === undefined || isNaN(percentage) || percentage < 0 === true) {
+                        let distributionAmount = 0
+                        let percentage = 0
+                        let config = UI.projects.governance.utilities.nodeCalculations.getDistributionConfig(childNode, false)
+                        if (config?.type === "amount" && config?.value >= 0) {
+                            distributionAmount = config.value * amountShare
+                            percentage = "fixed"
+                        } else if (config?.type === "percentage" && config?.value >= 0) {
+                            distributionAmount = percentagePower * config.value / 100
+                            percentage = config.value
+                        } else {
+                            distributionAmount = percentagePower * defaultPercentage / 100
                             percentage = defaultPercentage
                         }
-                        distributeProgramPower(childNode, programPower * percentage / 100, percentage, countingMode)
+                        distributeProgramPower(childNode, distributionAmount, percentage, countingMode)
                     }
                         break
                     case 'array': {
@@ -353,11 +412,20 @@ function newGovernanceFunctionLibraryClaimsProgram() {
                                 let childNode = propertyArray[m]
                                 if (childNode === undefined) { continue }
                                 if (childNode.type === "Tokens Awarded") { continue }
-                                let percentage = UI.projects.governance.utilities.nodeCalculations.percentage(childNode)
-                                if (percentage === undefined || isNaN(percentage) || percentage < 0 === true) {
+                                let distributionAmount = 0
+                                let percentage = 0
+                                let config = UI.projects.governance.utilities.nodeCalculations.getDistributionConfig(childNode, false)
+                                if (config?.type === "amount" && config?.value >= 0) {
+                                    distributionAmount = config.value * amountShare
+                                    percentage = "fixed"
+                                } else if (config?.type === "percentage" && config?.value >= 0) {
+                                    distributionAmount = percentagePower * config.value / 100
+                                    percentage = config.value
+                                } else {
+                                    distributionAmount = percentagePower * defaultPercentage / 100
                                     percentage = defaultPercentage
                                 }
-                                distributeProgramPower(childNode, programPower * percentage / 100, percentage, countingMode)
+                                distributeProgramPower(childNode, distributionAmount, percentage, countingMode)
                             }
                         }
                         break
@@ -464,11 +532,7 @@ function newGovernanceFunctionLibraryClaimsProgram() {
 
                 node.payload.uiObject.setValue(programPowerText, UI.projects.governance.globals.designer.SET_VALUE_COUNTER)
 
-                if (percentage !== undefined) {
-                    node.payload.uiObject.setPercentage(percentage.toFixed(2),
-                        UI.projects.governance.globals.designer.SET_PERCENTAGE_COUNTER
-                    )
-                }
+                UI.projects.governance.utilities.nodeCalculations.drawPercentage(node, percentage, undefined)
             }
         }
     }

--- a/Projects/Governance/UI/Function-Libraries/ClaimsProgram.js
+++ b/Projects/Governance/UI/Function-Libraries/ClaimsProgram.js
@@ -258,7 +258,7 @@ function newGovernanceFunctionLibraryClaimsProgram() {
                     if (countingMode === true) {
                         /*
                         Counting mode is the first round of execution and it is used to accumulate at the
-                        node being claimed all the claim poser of all claims to that node
+                        node being claimed all the claim power of all claims to that node
                         from any user profile. That will be used then to know how to split the reward
                         among all the claims, and to know how many claims in total there were.
                         */
@@ -300,6 +300,7 @@ function newGovernanceFunctionLibraryClaimsProgram() {
                     node.payload.referenceParent?.payload?.claimsProgram?.votes === undefined
                 ) {
                     node.payload.uiObject.resetStatus()
+                    drawProgramPower(node, programPower, percentage)
                 }
             } else {
                 if (node.type === 'Claims Program') {
@@ -526,13 +527,11 @@ function newGovernanceFunctionLibraryClaimsProgram() {
 
                 node.payload.uiObject.valueAngleOffset = 180
                 node.payload.uiObject.valueAtAngle = true
-                node.payload.uiObject.percentageAngleOffset = 180
-                node.payload.uiObject.percentageAtAngle = true
                 node.payload.tokenPower = programPower
 
                 node.payload.uiObject.setValue(programPowerText, UI.projects.governance.globals.designer.SET_VALUE_COUNTER)
 
-                UI.projects.governance.utilities.nodeCalculations.drawPercentage(node, percentage, undefined)
+                UI.projects.governance.utilities.nodeCalculations.drawPercentage(node, percentage, 180)
             }
         }
     }

--- a/Projects/Governance/UI/Function-Libraries/TokenPower.js
+++ b/Projects/Governance/UI/Function-Libraries/TokenPower.js
@@ -180,8 +180,17 @@ function newGovernanceFunctionLibraryTokenPower() {
             is going to be switched between all nodes. The first pass is about
             scanning all sibling nodes to see which ones have a percentage defined
             at their config, and check that all percentages don't add more than 100.
+
+            We will also check for nodes having absolute amounts of token power configured
+            and verify if the total of defined amounts is below the available token power.
+            If not, we will reduce the token power to be allocated equally by the share
+            of the configured amount exceeding the available amount.
+
+            Token Power remaining after servicing nodes with a configured amount will be
+            distributed to nodes with a configured percentage or with no configuration.
             */
             let totalPercentage = 0
+            let totalAmount = 0
             let totalNodesWithoutPercentage = 0
             for (let i = 0; i < schemaDocument.childrenNodesProperties.length; i++) {
                 let property = schemaDocument.childrenNodesProperties[i]
@@ -193,13 +202,15 @@ function newGovernanceFunctionLibraryTokenPower() {
                         if (childNode.type === "Delegation Program" && excludeDelegationProgram === true) { continue }
                         if (OPAQUE_NODES_TYPES.includes(childNode.type)) { continue }
 
-                        let percentage = UI.projects.governance.utilities.nodeCalculations.percentage(childNode)
+                        let config = UI.projects.governance.utilities.nodeCalculations.getDistributionConfig(childNode, "tokenPower")
 
-                        if (percentage !== undefined && isNaN(percentage) !== true && percentage >= 0) {
-                            totalPercentage = totalPercentage + percentage
+                        if (config?.type === "amount" && config?.value >= 0) {
+                            totalAmount = totalAmount + config.value
+                        } else if (config?.type === "percentage" && config?.value >= 0) {
+                            totalPercentage = totalPercentage + config.value
                         } else {
                             totalNodesWithoutPercentage++
-                        }
+                        }                
                     }
                         break
                     case 'array': {
@@ -211,9 +222,12 @@ function newGovernanceFunctionLibraryTokenPower() {
                                 if (childNode.type === "Delegation Program" && excludeDelegationProgram === true) { continue }
                                 if (OPAQUE_NODES_TYPES.includes(childNode.type)) { continue }
 
-                                let percentage = UI.projects.governance.utilities.nodeCalculations.percentage(childNode)
-                                if (percentage !== undefined && isNaN(percentage) !== true && percentage >= 0) {
-                                    totalPercentage = totalPercentage + percentage
+                                let config = UI.projects.governance.utilities.nodeCalculations.getDistributionConfig(childNode, "tokenPower")
+
+                                if (config?.type === "amount" && config?.value >= 0) {
+                                    totalAmount = totalAmount + config.value
+                                } else if (config?.type === "percentage" && config?.value >= 0) {
+                                    totalPercentage = totalPercentage + config.value
                                 } else {
                                     totalNodesWithoutPercentage++
                                 }
@@ -234,6 +248,17 @@ function newGovernanceFunctionLibraryTokenPower() {
             if (totalNodesWithoutPercentage > 0) {
                 defaultPercentage = (100 - totalPercentage) / totalNodesWithoutPercentage
             }
+            
+            /* If configured Token Power amounts exceed the available Token Power, determine the share by which requests need to be reduced.
+            Store the Token Power remaining for distribution via percentages after all amount requests have been served in percentagePower. */
+            let percentagePower = 0
+            let amountShare = 1
+            if (totalAmount > tokenPower && totalAmount > 0) {
+                amountShare = tokenPower / totalAmount
+            } else {
+                percentagePower = tokenPower - totalAmount
+            }
+
             /*
             Here we do the actual distribution.
             */
@@ -247,13 +272,24 @@ function newGovernanceFunctionLibraryTokenPower() {
                         if (childNode.type === "Delegation Program" && excludeDelegationProgram === true) { continue }
                         if (OPAQUE_NODES_TYPES.includes(childNode.type)) { continue }
 
-                        let percentage = UI.projects.governance.utilities.nodeCalculations.percentage(childNode)
-                        if (percentage === undefined || isNaN(percentage)  || percentage < 0 === true) {
+                        let distributionAmount = 0
+                        let percentage = 0
+                        let config = UI.projects.governance.utilities.nodeCalculations.getDistributionConfig(childNode, "tokenPower")
+
+                        if (config?.type === "amount" && config?.value >= 0) {
+                            distributionAmount = config.value * amountShare
+                            percentage = "fixed"
+                        } else if (config?.type === "percentage" && config?.value >= 0) {
+                            distributionAmount = percentagePower * config.value / 100
+                            percentage = config.value
+                        } else {
+                            distributionAmount = percentagePower * defaultPercentage / 100
                             percentage = defaultPercentage
                         }
+
                         distributeTokenPower(
                             childNode,
-                            tokenPower * percentage / 100,
+                            distributionAmount,
                             percentage,
                             excludeDelegationProgram
                         )
@@ -268,13 +304,24 @@ function newGovernanceFunctionLibraryTokenPower() {
                                 if (childNode.type === "Delegation Program" && excludeDelegationProgram === true) { continue }
                                 if (OPAQUE_NODES_TYPES.includes(childNode.type)) { continue }
 
-                                let percentage = UI.projects.governance.utilities.nodeCalculations.percentage(childNode)
-                                if (percentage === undefined || isNaN(percentage)  || percentage < 0 === true) {
+                                let distributionAmount = 0
+                                let percentage = 0
+                                let config = UI.projects.governance.utilities.nodeCalculations.getDistributionConfig(childNode, "tokenPower")
+        
+                                if (config?.type === "amount" && config?.value >= 0) {
+                                    distributionAmount = config.value * amountShare
+                                    percentage = "fixed"
+                                } else if (config?.type === "percentage" && config?.value >= 0) {
+                                    distributionAmount = percentagePower * config.value / 100
+                                    percentage = config.value
+                                } else {
+                                    distributionAmount = percentagePower * defaultPercentage / 100
                                     percentage = defaultPercentage
                                 }
+
                                 distributeTokenPower(
                                     childNode,
-                                    tokenPower * percentage / 100,
+                                    distributionAmount,
                                     percentage,
                                     excludeDelegationProgram
                                 )
@@ -313,13 +360,7 @@ function newGovernanceFunctionLibraryTokenPower() {
                 node.payload.uiObject.setStatus(tokenPowerText, UI.projects.governance.globals.designer.SET_STATUS_COUNTER)
             }
 
-            if (percentage !== undefined) {
-                node.payload.uiObject.percentageAngleOffset = 180
-                node.payload.uiObject.percentageAtAngle = true
-                node.payload.uiObject.setPercentage(percentage.toFixed(2),
-                    UI.projects.governance.globals.designer.SET_PERCENTAGE_COUNTER
-                )
-            }
+            UI.projects.governance.utilities.nodeCalculations.drawPercentage(node, percentage, 180)
         }
-    }
+    }    
 }

--- a/Projects/Governance/UI/Function-Libraries/Tokens.js
+++ b/Projects/Governance/UI/Function-Libraries/Tokens.js
@@ -118,6 +118,12 @@ function newGovernanceFunctionLibraryTokens() {
         ) {
             node.payload.tokens = tokens * node.payload.weight
             drawTokenFlow(node, node.payload.tokens, node.payload.weight)
+        } else if (
+            isNaN(node.payload.weight) !== true &&
+            node.payload.weight !== undefined &&
+            node.payload.weight === 0   
+        ) {
+            node.payload.uiObject.resetStatus()
         }
         /*
         If there is a reference parent defined, this means that the token flow is 

--- a/Projects/Governance/UI/Function-Libraries/VotingProgram.js
+++ b/Projects/Governance/UI/Function-Libraries/VotingProgram.js
@@ -32,7 +32,7 @@ function newGovernanceFunctionLibraryVotingProgram() {
             resetVotes(assetsNode)
         }
 
-        /* Reset Votes at Features */
+        /* Reset Votes at Positions */
         for (let i = 0; i < positions.length; i++) {
             let positionsNode = positions[i]
             resetVotes(positionsNode)
@@ -321,6 +321,7 @@ function newGovernanceFunctionLibraryVotingProgram() {
                     at their config, and check that all percentages don't add more than 100.
                     */
                     let totalPercentage = 0
+                    let totalAmount = 0
                     let totalNodesWithoutPercentage = 0
                     for (let i = 0; i < schemaDocument.childrenNodesProperties.length; i++) {
                         let property = schemaDocument.childrenNodesProperties[i]
@@ -330,12 +331,14 @@ function newGovernanceFunctionLibraryVotingProgram() {
                                 let childNode = node[property.name]
                                 if (childNode === undefined) { continue }
                                 if (childNode.type === 'Tokens Bonus') { continue }
-                                let percentage = UI.projects.governance.utilities.nodeCalculations.percentage(childNode)
-                                if (percentage !== undefined && isNaN(percentage) !== true && percentage >= 0) {
-                                    totalPercentage = totalPercentage + percentage
+                                let config = UI.projects.governance.utilities.nodeCalculations.getDistributionConfig(childNode, 'voting')
+                                if (config?.type === "amount" && config?.value >= 0) {
+                                    totalAmount = totalAmount + config.value
+                                } else if (config?.type === "percentage" && config?.value >= 0) {
+                                    totalPercentage = totalPercentage + config.value
                                 } else {
                                     totalNodesWithoutPercentage++
-                                }
+                                }  
                             }
                                 break
                             case 'array': {
@@ -345,9 +348,11 @@ function newGovernanceFunctionLibraryVotingProgram() {
                                         let childNode = propertyArray[m]
                                         if (childNode === undefined) { continue }
                                         if (childNode.type === 'Tokens Bonus') { continue }
-                                        let percentage = UI.projects.governance.utilities.nodeCalculations.percentage(childNode)
-                                        if (percentage !== undefined && isNaN(percentage) !== true && percentage >= 0) {
-                                            totalPercentage = totalPercentage + percentage
+                                        let config = UI.projects.governance.utilities.nodeCalculations.getDistributionConfig(childNode, 'voting')
+                                        if (config?.type === "amount" && config?.value >= 0) {
+                                            totalAmount = totalAmount + config.value
+                                        } else if (config?.type === "percentage" && config?.value >= 0) {
+                                            totalPercentage = totalPercentage + config.value
                                         } else {
                                             totalNodesWithoutPercentage++
                                         }
@@ -359,7 +364,7 @@ function newGovernanceFunctionLibraryVotingProgram() {
                     }
                     if (totalPercentage > 100) {
                         node.payload.uiObject.setErrorMessage(
-                            'Voting Power Switching Error. Total Percentage of children nodes is grater that 100.',
+                            'Voting Power Switching Error. Total Percentage of children nodes is grater than 100.',
                             UI.projects.governance.globals.designer.SET_ERROR_COUNTER_FACTOR
                         )
                         return
@@ -367,6 +372,15 @@ function newGovernanceFunctionLibraryVotingProgram() {
                     let defaultPercentage = 0
                     if (totalNodesWithoutPercentage > 0) {
                         defaultPercentage = (100 - totalPercentage) / totalNodesWithoutPercentage
+                    }
+                    /* If configured Amounts exceed the available Votes, determine the share by which requests need to be reduced.
+                    Store the Votes remaining for distribution via percentages after all amount requests have been served in percentagePower. */
+                    let percentagePower = 0
+                    let amountShare = 1
+                    if (totalAmount > votes && totalAmount > 0) {
+                        amountShare = votes / totalAmount
+                    } else {
+                        percentagePower = votes - totalAmount
                     }
                     /*
                     Here we do the actual distribution.
@@ -379,14 +393,23 @@ function newGovernanceFunctionLibraryVotingProgram() {
                                 let childNode = node[property.name]
                                 if (childNode === undefined) { continue }
                                 if (childNode.type === 'Tokens Bonus') { continue }
-                                let percentage = UI.projects.governance.utilities.nodeCalculations.percentage(childNode)
-                                if (percentage === undefined || isNaN(percentage)  || percentage < 0 === true) {
+                                let distributionAmount = 0
+                                let percentage = 0
+                                let config = UI.projects.governance.utilities.nodeCalculations.getDistributionConfig(childNode, 'voting')
+                                if (config?.type === "amount" && config?.value >= 0) {
+                                    distributionAmount = config.value * amountShare
+                                    percentage = "fixed"
+                                } else if (config?.type === "percentage" && config?.value >= 0) {
+                                    distributionAmount = percentagePower * config.value / 100
+                                    percentage = config.value
+                                } else {
+                                    distributionAmount = percentagePower * defaultPercentage / 100
                                     percentage = defaultPercentage
                                 }
                                 distributeProgramPower(
                                     currentProgramNode,
                                     childNode,
-                                    votes * percentage / 100,
+                                    distributionAmount,
                                     percentage,
                                     generation,
                                     userProfile
@@ -400,14 +423,23 @@ function newGovernanceFunctionLibraryVotingProgram() {
                                         let childNode = propertyArray[m]
                                         if (childNode === undefined) { continue }
                                         if (childNode.type === 'Tokens Bonus') { continue }
-                                        let percentage = UI.projects.governance.utilities.nodeCalculations.percentage(childNode)
-                                        if (percentage === undefined || isNaN(percentage)  || percentage < 0 === true) {
+                                        let distributionAmount = 0
+                                        let percentage = 0
+                                        let config = UI.projects.governance.utilities.nodeCalculations.getDistributionConfig(childNode, 'voting')
+                                        if (config?.type === "amount" && config?.value >= 0) {
+                                            distributionAmount = config.value * amountShare
+                                            percentage = "fixed"
+                                        } else if (config?.type === "percentage" && config?.value >= 0) {
+                                            distributionAmount = percentagePower * config.value / 100
+                                            percentage = config.value
+                                        } else {
+                                            distributionAmount = percentagePower * defaultPercentage / 100
                                             percentage = defaultPercentage
                                         }
                                         distributeProgramPower(
                                             currentProgramNode,
                                             childNode,
-                                            votes * percentage / 100,
+                                            distributionAmount,
                                             percentage,
                                             generation,
                                             userProfile
@@ -433,11 +465,7 @@ function newGovernanceFunctionLibraryVotingProgram() {
             if (node.type === 'Voting Program') {
                 drawProgram(node, userProfile)
 
-                if (percentage !== undefined) {
-                    node.payload.uiObject.setPercentage(percentage.toFixed(2),
-                        UI.projects.governance.globals.designer.SET_PERCENTAGE_COUNTER
-                    )
-                }
+                UI.projects.governance.utilities.nodeCalculations.drawPercentage(node, percentage, undefined)
                 return
             }
             if (node.type === 'User Profile Vote') {
@@ -485,13 +513,7 @@ function newGovernanceFunctionLibraryVotingProgram() {
 
             node.payload.uiObject.setValue(votesText, UI.projects.governance.globals.designer.SET_VALUE_COUNTER)
 
-            if (percentage !== undefined) {
-                node.payload.uiObject.percentageAngleOffset = 180
-                node.payload.uiObject.percentageAtAngle = true
-                node.payload.uiObject.setPercentage(percentage.toFixed(2),
-                    UI.projects.governance.globals.designer.SET_PERCENTAGE_COUNTER
-                )
-            }
+            UI.projects.governance.utilities.nodeCalculations.drawPercentage(node, percentage, 180)
 
 
             function drawUserNode(node, votes, percentage) {
@@ -504,18 +526,15 @@ function newGovernanceFunctionLibraryVotingProgram() {
 
                     node.payload.uiObject.setValue(outgoingPowerText + ' Voting Power', UI.projects.governance.globals.designer.SET_VALUE_COUNTER)
 
-                    node.payload.uiObject.percentageAngleOffset = 180
-                    node.payload.uiObject.percentageAtAngle = true
-
-                    node.payload.uiObject.setPercentage(percentage,
-                        UI.projects.governance.globals.designer.SET_PERCENTAGE_COUNTER
-                    )
+                    UI.projects.governance.utilities.nodeCalculations.drawPercentage(node, percentage, 180)
 
                     if (node.payload.referenceParent !== undefined) {
                         node.payload.uiObject.statusAngleOffset = 0
                         node.payload.uiObject.statusAtAngle = true
 
                         node.payload.uiObject.setStatus(outgoingPowerText + ' ' + ' Outgoing Power', UI.projects.governance.globals.designer.SET_STATUS_COUNTER)
+                    } else {
+                        node.payload.uiObject.resetStatus()
                     }
                 }
             }

--- a/Projects/Governance/UI/Utilities/DecendentProgram.js
+++ b/Projects/Governance/UI/Utilities/DecendentProgram.js
@@ -270,7 +270,6 @@ function newGovernanceUtilitiesDecendentProgram() {
                         of all Program nodes.
                         */
                         accumulatedIncomingProgramPower = accumulatedIncomingProgramPower + node.payload[programPropertyName].incomingPower
-                        node.payload.tokenPower = accumulatedIncomingProgramPower
 
                         if (node[usersArrayPropertyName] !== undefined) {
                             /*
@@ -280,15 +279,18 @@ function newGovernanceUtilitiesDecendentProgram() {
                             at their config, and check that all percentages don't add more than 100.
                             */
                             let totalPercentage = 0
+                            let totalAmount = 0
                             let totalNodesWithoutPercentage = 0
                             for (let i = 0; i < node[usersArrayPropertyName].length; i++) {
                                 let childNode = node[usersArrayPropertyName][i]
-                                let percentage = UI.projects.governance.utilities.nodeCalculations.percentage(childNode)
-                                if (percentage !== undefined && isNaN(percentage) !== true && percentage >= 0) {
-                                    totalPercentage = totalPercentage + percentage
+                                let config = UI.projects.governance.utilities.nodeCalculations.getDistributionConfig(childNode, 'descendent', programPropertyName)
+                                if (config?.type === "amount" && config?.value >= 0) {
+                                    totalAmount = totalAmount + config.value
+                                } else if (config?.type === "percentage" && config?.value >= 0) {
+                                    totalPercentage = totalPercentage + config.value
                                 } else {
                                     totalNodesWithoutPercentage++
-                                }
+                                }  
                             }
                             if (totalPercentage > 100) {
                                 node.payload.uiObject.setErrorMessage(
@@ -301,19 +303,35 @@ function newGovernanceUtilitiesDecendentProgram() {
                             if (totalNodesWithoutPercentage > 0) {
                                 defaultPercentage = (100 - totalPercentage) / totalNodesWithoutPercentage
                             }
+                            let percentagePower = 0
+                            let amountShare = 1
+                            if (totalAmount > programPower && totalAmount > 0) {
+                                amountShare = programPower / totalAmount
+                            } else {
+                                percentagePower = programPower - totalAmount
+                            }
                             /*
                             Here we do the actual distribution.
                             */
                             for (let i = 0; i < node[usersArrayPropertyName].length; i++) {
                                 let childNode = node[usersArrayPropertyName][i]
-                                let percentage = UI.projects.governance.utilities.nodeCalculations.percentage(childNode)
-                                if (percentage === undefined || isNaN(percentage)  || percentage < 0 === true) {
+                                let distributionAmount = 0
+                                let percentage = 0
+                                let config = UI.projects.governance.utilities.nodeCalculations.getDistributionConfig(childNode, 'descendent', programPropertyName)
+                                if (config?.type === "amount" && config?.value >= 0) {
+                                    distributionAmount = config.value * amountShare
+                                    percentage = "fixed"
+                                } else if (config?.type === "percentage" && config?.value >= 0) {
+                                    distributionAmount = percentagePower * config.value / 100
+                                    percentage = config.value
+                                } else {
+                                    distributionAmount = percentagePower * defaultPercentage / 100
                                     percentage = defaultPercentage
                                 }
                                 distributeProgramPower(
                                     currentProgramNode, 
                                     childNode, 
-                                    programPower * percentage / 100, 
+                                    distributionAmount, 
                                     0, 
                                     percentage, 
                                     generation
@@ -324,7 +342,7 @@ function newGovernanceUtilitiesDecendentProgram() {
                     }
                     case userNodeType: {
                         let previousOutgoing = node.payload[programPropertyName].outgoingPower
-                        node.payload[programPropertyName].outgoingPower = node.payload.parentNode.payload[programPropertyName].outgoingPower * percentage / 100
+                        node.payload[programPropertyName].outgoingPower = node.payload[programPropertyName].outgoingPower + programPower
 
                         drawUserNode(node, percentage)
                         if (node.payload.referenceParent !== undefined) {
@@ -404,12 +422,7 @@ function newGovernanceUtilitiesDecendentProgram() {
 
                 node.payload.uiObject.setValue(outgoingPowerText + ' ' + programPowerName, UI.projects.governance.globals.designer.SET_VALUE_COUNTER)
 
-                node.payload.uiObject.percentageAngleOffset = 180
-                node.payload.uiObject.percentageAtAngle = true
-
-                node.payload.uiObject.setPercentage(percentage,
-                    UI.projects.governance.globals.designer.SET_PERCENTAGE_COUNTER
-                    )
+                UI.projects.governance.utilities.nodeCalculations.drawPercentage(node, percentage, 180)
 
                 node.payload.uiObject.statusAngleOffset = 0
                 node.payload.uiObject.statusAtAngle = true

--- a/Projects/Governance/UI/Utilities/DescendentTables.js
+++ b/Projects/Governance/UI/Utilities/DescendentTables.js
@@ -40,7 +40,7 @@ function newGovernanceUtilitiesDecendentTables() {
                     "type": "number",
                     "order": "descending",
                     "textAlign": "center",
-                    "format": "2 decimals"
+                    "format": "integer"
                 },
                 {
                     "name": "incoming",
@@ -48,7 +48,7 @@ function newGovernanceUtilitiesDecendentTables() {
                     "type": "number",
                     "order": "descending",
                     "textAlign": "center",
-                    "format": "2 decimals"
+                    "format": "integer"
                 },
                 {
                     "name": "tokensAwarded",
@@ -56,7 +56,7 @@ function newGovernanceUtilitiesDecendentTables() {
                     "type": "number",
                     "order": "descending",
                     "textAlign": "center",
-                    "format": "2 decimals"
+                    "format": "integer"
                 },
                 {
                     "name": "decendants",
@@ -72,7 +72,7 @@ function newGovernanceUtilitiesDecendentTables() {
                     "type": "number",
                     "order": "descending",
                     "textAlign": "center",
-                    "format": "2 decimals"
+                    "format": "integer"
                 }
             ]
         }
@@ -95,11 +95,11 @@ function newGovernanceUtilitiesDecendentTables() {
 
             let tableRecord = {
                 "name": userProfile.name,
-                "ownPower": program.payload[programPropertyName].ownPower | 0,
-                "incoming": program.payload[programPropertyName].incomingPower | 0,
-                "tokensAwarded": program.payload[programPropertyName].awarded.tokens | 0,
-                "decendants": program.payload[programPropertyName].awarded.count | 0,
-                "tokensBonus": program.payload[programPropertyName].bonus.tokens | 0
+                "ownPower": program.payload[programPropertyName].ownPower || 0,
+                "incoming": program.payload[programPropertyName].incomingPower || 0,
+                "tokensAwarded": program.payload[programPropertyName].awarded.tokens || 0,
+                "decendants": program.payload[programPropertyName].awarded.count || 0,
+                "tokensBonus": program.payload[programPropertyName].bonus.tokens || 0
             }
 
             if (UI.projects.governance.utilities.filters.applyFilters(filters, filtersObject, tableRecord) === true) {

--- a/Projects/Governance/UI/Utilities/NodeCalculations.js
+++ b/Projects/Governance/UI/Utilities/NodeCalculations.js
@@ -1,6 +1,5 @@
 function newGovernanceUtilitiesNodeCalculations() {
     let thisObject = {
-       // percentage: percentage,
         getDistributionConfig: getDistributionConfig,
         drawPercentage: drawPercentage
     }
@@ -8,54 +7,6 @@ function newGovernanceUtilitiesNodeCalculations() {
     return thisObject
 
     // We will calculate the preferred power allocation percentage by using either the user defined 'percentage' or the user defined 'amount' in the node config.
-   /*
-    function percentage(node) {
-        if (node.config !== undefined) {
-            try {
-                JSON.parse(node.config)
-            }
-            catch (error) {
-                return
-            }
-            let config = JSON.parse(node.config)
-            let percentage = config.percentage
-            let amount = config.amount
-            let parentPower = node.payload.parentNode.payload.tokenPower
-
-            // Check that not both are defined
-            if (percentage !== undefined && amount !== undefined) {
-                node.payload.uiObject.setErrorMessage(
-                    'Both "amount" and "percentage" are present in the config - Only one may be defined.',
-                    10
-                )
-                return
-            }
-
-            // If only 'percentage' is defined, we return that number
-            else if (isFinite(percentage) && !isFinite(amount)) {
-                return percentage
-            }
-
-            // If only 'amount' is defined, we use calculate what percentage 'amount' is of the 'parentPower'.
-            else if (!isFinite(percentage) && isFinite(amount) && isFinite(parentPower)) {
-                percentage = (amount / parentPower) * 100
-
-                // If the 'amount' is greater than what is available at the parent node, we assume it is intended and is used as a "maximum power".
-                if (percentage > 100) {
-                    return 100
-                }
-                return percentage
-            }
-
-            // If user havn't defined any of the values in the config, we return 'undefined'
-            else {
-                return undefined
-            }
-        }
-        return
-    }
-*/
-
     function getDistributionConfig(node, mode, programPropertyName) {
         if (node.payload === undefined) { return }
         let result = { type: undefined, value: undefined }

--- a/Projects/Governance/UI/Utilities/NodeCalculations.js
+++ b/Projects/Governance/UI/Utilities/NodeCalculations.js
@@ -1,12 +1,14 @@
 function newGovernanceUtilitiesNodeCalculations() {
     let thisObject = {
-        percentage: percentage
+        percentage: percentage,
+        getDistributionConfig: getDistributionConfig,
+        drawPercentage: drawPercentage
     }
 
     return thisObject
 
     // We will calculate the preferred power allocation percentage by using either the user defined 'percentage' or the user defined 'amount' in the node config.
-
+   
     function percentage(node) {
         if (node.config !== undefined) {
             try {
@@ -52,4 +54,59 @@ function newGovernanceUtilitiesNodeCalculations() {
         }
         return
     }
+
+
+    function getDistributionConfig(node, mode) {
+        if (node.payload === undefined) { return }
+        let result = {}
+        let amount = UI.projects.visualScripting.utilities.nodeConfig.loadConfigProperty(node.payload, 'amount')
+        let percentage = UI.projects.visualScripting.utilities.nodeConfig.loadConfigProperty(node.payload, 'percentage')
+
+        if (percentage !== undefined && amount !== undefined) { return }
+
+        /* Node configuration requests an absolute amount of available power */
+        if (amount !== undefined) {
+            result.type = "amount"
+            /* We do not allow amounts smaller than 0 */
+            if (!isFinite(amount) || amount < 0) { return }
+            /* Check if the node already has token power and reduce the result accordingly */
+            if (mode === "tokenPower" && node.payload.tokenPower !== undefined && isFinite(node.payload.tokenPower)) {
+                let neededTokenPower = amount - node.payload.tokenPower
+                if (neededTokenPower < 0) { neededTokenPower = 0}
+                result.value = neededTokenPower
+            } else if (mode === "voting" && node.payload.votingProgram?.votes !== undefined && isFinite(node.payload.votingProgram?.votes)) {
+                let neededVotes = amount - node.payload.votingProgram.votes
+                if (neededVotes < 0) { neededVotes = 0 }
+                result.value = neededVotes
+            } else {
+                result.value = amount
+            }           
+        /* Node configuration requests a percentage of available power  */
+        } else if (percentage !== undefined) {
+            result.type = "percentage"
+            /* We do not allow percentages smaller than 0 */
+            if (!isFinite(percentage) || percentage < 0) { return }
+            result.value = percentage
+        } else {
+            return
+        }
+        return result
+    }
+
+    function drawPercentage(node, percentage, percentageAngleOffset) {
+        /* Outputs percentage power allocations at nodes, depending if the allocation is percentage or absolute amount-based */
+        if (node === undefined) { return }
+        if (percentage === undefined) { return }
+        if (isNaN(percentage)) {
+            node.payload.uiObject.resetPercentage()
+        } else {
+            if (percentageAngleOffset !== undefined && isFinite(percentageAngleOffset)) {
+                node.payload.uiObject.percentageAngleOffset = percentageAngleOffset
+                node.payload.uiObject.percentageAtAngle = true
+            }
+            node.payload.uiObject.setPercentage(percentage.toFixed(2),
+            UI.projects.governance.globals.designer.SET_PERCENTAGE_COUNTER)
+        }
+    }
+
 }


### PR DESCRIPTION
This PR is mainly driven by a larger refactoring for the allocation of token power via a fixed amount ("amount" parameter). The previous implementation led to unexpected calculation results im excess of the determined amounts when the user had delegated power available. Due to this fix, I would recommend to merge this before the next distribution. 
@cozed-gh - fyi

As I needed to touch many parts of Governance for this, I used the opportunity for a number of further optimizations:
- Fix of a bug in descendent programs (Referral / Support...), leading to wrong calculations of Own Power.
- Introduction of the "claimedShare" parameter which allows to claim a specific share of a rewards pool
- When a node's power drops to 0 (e.g. due to negative voting), the effect is now displayed faster in the UI.