### PR TITLE
Event Server: Hardening Websockets Connections

### DIFF
--- a/Platform/Client/webSocketsInterface.js
+++ b/Platform/Client/webSocketsInterface.js
@@ -36,6 +36,22 @@
 
                 socket.on('message', onMessage)
 
+                /* Terminate pinging connections for which we don't receive a keepalive signal every 10 seconds (+2 sec grace period) */
+                /* Not for each opening connection, as not all clients are pinging */
+                //socket.on('open', heartbeat)
+                socket.on('ping', heartbeat)
+                socket.on('close', function clear() {
+                    clearTimeout(socket.pingTimeout)
+                })
+
+                function heartbeat() {
+                    clearTimeout(socket.pingTimeout)
+                    socket.pingTimeout = setTimeout(() => {
+                        SA.logger.error('Client -> Web Sockets Interface -> setUpWebSocketServer -> No keepalive signal received, terminating connection')
+                        socket.terminate()
+                    }, 10000 + 2000)
+                }
+                
                 function onMessage(message) {
                     // Here is where all messages will be received through the websocket
        

--- a/Projects/Foundations/TS/Task-Modules/EventServerClient.js
+++ b/Projects/Foundations/TS/Task-Modules/EventServerClient.js
@@ -19,6 +19,9 @@
 
     let WEB_SOCKETS_CLIENT
     const WEB_SOCKET = SA.nodeModules.ws
+    
+    let isAlive = false
+    let pingInterval
 
     if (host === undefined) {
         host = 'localhost'
@@ -56,7 +59,11 @@
                     if (INFO_LOG === true) {
                         SA.logger.info('Websocket connection opened.')
                     }
-    
+                    
+                    /* Send keepalive message every 10 seconds */
+                    isAlive = true
+                    pingInterval = setInterval(ping, 10000)
+
                     if (callBackFunction !== undefined) {
                         callBackFunction()
                     }
@@ -64,6 +71,7 @@
                     SA.logger.error('Task Server -> Event Server Client -> setuptWebSockets ->  onopen -> err = ' + err.stack) 
                 }
             }
+            WEB_SOCKETS_CLIENT.on('pong', heartbeat)
             WEB_SOCKETS_CLIENT.onmessage = e => {
                 try {
                     if (INFO_LOG === true) {
@@ -119,6 +127,7 @@
             }
             sendCommand(eventCommand)
         }
+        clearInterval(pingInterval)
         WEB_SOCKETS_CLIENT.close();
     }
 
@@ -155,6 +164,20 @@
         }
     }
 
+    function ping() {
+        if (isAlive === false) {
+            WEB_SOCKETS_CLIENT.terminate()
+            SA.logger.error('Task Server -> Event Server Client -> No connection keep-alive signal received. Terminating and trying to re-initialize.')
+            setuptWebSockets()
+        }
+        isAlive = false
+        WEB_SOCKETS_CLIENT.ping()
+    }
+
+    function heartbeat() {
+        isAlive = true
+    }
+    
     function createEventHandler(eventHandlerName, callerId, responseCallBack) {
         let eventCommand = {
             action: 'createEventHandler',

--- a/Projects/Network/SA/Modules/P2PNetworkStart.js
+++ b/Projects/Network/SA/Modules/P2PNetworkStart.js
@@ -201,7 +201,7 @@ exports.newNetworkModulesP2PNetworkStart = function newNetworkModulesP2PNetworkS
         messagesToBeDelivered.push(messageHeader)
 
         if (peer === undefined) {
-            SA.logger.error('Message can not be delivered to the P2P Network because the peer selected is undefined. Maybe there are no peers for the Network Service that wants to be accesed?')
+            SA.logger.error('Message can not be delivered to the P2P Network because the peer selected is undefined. Maybe there are no peers for the Network Service that wants to be accessed?')
             return
         }
         /*


### PR DESCRIPTION
A log analysis of the recent Trend Soaring outages revealed that occasionally, raised events may not arrive at the listening client. This change hardens the Websockets connections between Event Server and Event Client by implementing a 10-second heartbeat logic.