### PR TITLE
Websockets: Simplified Heartbeat for Event Server Clients

### DIFF
--- a/Projects/Foundations/TS/Task-Modules/EventServerClient.js
+++ b/Projects/Foundations/TS/Task-Modules/EventServerClient.js
@@ -19,6 +19,9 @@
 
     let WEB_SOCKETS_CLIENT
     const WEB_SOCKET = SA.nodeModules.ws
+    
+    let isAlive = false
+    let pingInterval
 
     if (host === undefined) {
         host = 'localhost'
@@ -56,7 +59,11 @@
                     if (INFO_LOG === true) {
                         SA.logger.info('Websocket connection opened.')
                     }
-    
+                    
+                    /* Send keepalive message every 10 seconds */
+                    isAlive = true
+                    pingInterval = setInterval(ping, 10000)
+
                     if (callBackFunction !== undefined) {
                         callBackFunction()
                     }
@@ -64,8 +71,12 @@
                     SA.logger.error('Task Server -> Event Server Client -> setuptWebSockets ->  onopen -> err = ' + err.stack) 
                 }
             }
+            WEB_SOCKETS_CLIENT.on('pong', heartbeat)
             WEB_SOCKETS_CLIENT.onmessage = e => {
                 try {
+                    /* If we receive a message, the connection is alive. */                    
+                    heartbeat()
+                    
                     if (INFO_LOG === true) {
                         SA.logger.info('Websocket Message Received: ' + e.data.substring(0, 1000))
                     }
@@ -119,6 +130,7 @@
             }
             sendCommand(eventCommand)
         }
+        clearInterval(pingInterval)
         WEB_SOCKETS_CLIENT.close();
     }
 
@@ -155,6 +167,21 @@
         }
     }
 
+    function ping() {
+        if (isAlive === false) {
+            WEB_SOCKETS_CLIENT.terminate()
+            SA.logger.error('Task Server -> Event Server Client -> No connection keep-alive signal received. Terminating and trying to re-initialize.')
+            setuptWebSockets()
+            return
+        }
+        isAlive = false
+        WEB_SOCKETS_CLIENT.ping()
+    }
+
+    function heartbeat() {
+        isAlive = true
+    }
+    
     function createEventHandler(eventHandlerName, callerId, responseCallBack) {
         let eventCommand = {
             action: 'createEventHandler',

--- a/Projects/Network/SA/Modules/P2PNetworkStart.js
+++ b/Projects/Network/SA/Modules/P2PNetworkStart.js
@@ -201,7 +201,7 @@ exports.newNetworkModulesP2PNetworkStart = function newNetworkModulesP2PNetworkS
         messagesToBeDelivered.push(messageHeader)
 
         if (peer === undefined) {
-            SA.logger.error('Message can not be delivered to the P2P Network because the peer selected is undefined. Maybe there are no peers for the Network Service that wants to be accesed?')
+            SA.logger.error('Message can not be delivered to the P2P Network because the peer selected is undefined. Maybe there are no peers for the Network Service that wants to be accessed?')
             return
         }
         /*


### PR DESCRIPTION
Following the earlier effort with of PR #4833 which caused issues in several unexpected use-cases such as backtesting, this heartbeat implementation is now simplified, working only from client side (not from server side) and interpreting any incoming message as an indication of an active connection.

Contributes to #4727 .