### PR TITLE
Trading Signals: Deactivating signal broadcasting for non-followers

### DIFF
--- a/Dashboards/DashboardsApp.js
+++ b/Dashboards/DashboardsApp.js
@@ -10,7 +10,7 @@ exports.newDashboardsApp = function newDashboardsApp() {
         
         process.on('uncaughtException', function (err) {
             if (err.message && err.message.indexOf("EADDRINUSE") > 0) {
-                SA.logger.error("The Superalgos Dashboards Client cannot be started. Reason: the port configured migth be being used by another application, or Superalgos Dashboards Client might be already running.")
+                SA.logger.error("The Superalgos Dashboards Client cannot be started. Reason: the port configured might be being used by another application, or Superalgos Dashboards Client might be already running.")
                 return
             }
             SA.logger.error('Dashboards App -> uncaughtException -> err.message = ' + err.message)

--- a/Platform/PlatformApp.js
+++ b/Platform/PlatformApp.js
@@ -10,7 +10,7 @@ exports.newPlatformApp = function newPlatformApp() {
 
         process.on('uncaughtException', function (err) {
             if (err.message && err.message.indexOf("EADDRINUSE") > 0) {
-                SA.logger.info("The Superalgos Platform Client cannot be started. Reason: the port configured migth be being used by another application, or Superalgos Platform Client might be already running.")
+                SA.logger.info("The Superalgos Platform Client cannot be started. Reason: the port configured might be being used by another application, or Superalgos Platform Client might be already running.")
                 return
             }
             SA.logger.error('Platform App -> uncaughtException -> err.message = ' + err.message)

--- a/Projects/Simulation/TS/Function-Libraries/SimulationFunctions.js
+++ b/Projects/Simulation/TS/Function-Libraries/SimulationFunctions.js
@@ -242,8 +242,9 @@ exports.newSimulationFunctionLibrariesSimulationFunctions = function () {
                     else {
                         SA.logger.warn('Signal for current candle was NEVER received while running the simulation. Candle Index = ' + candleIndex + ' # of retries = ' + retries + ' / ' + MAX_RETRIES)
                         SA.logger.warn('The possible reasons for this to happen are: ')
-                        SA.logger.warn('                                             1) If you never received the signals from this provider before, you might be using an outdated User Profile of the Signal Provider. ')
-                        SA.logger.warn('                                             2) If you were receiving before signals from this Signal Provider, then maybe the provider stopped sending signals. Please check the providers Telegram Group for any notifications.')
+                        SA.logger.warn('    1) You may not be following the Signal Provider. Ensure a Followed Bot Reference node is added to the referenced Social Trading Bot in your User Profile. ')
+                        SA.logger.warn('    2) You may be using an outdated User Profile of the Signal Provider. Please make sure your setup is up to date. ')
+                        SA.logger.warn('    3) The Signal Provider may have stopped sending signals. Please check the provider\'s Telegram Group for any notifications.')
                         
                         allGood = false
                         break

--- a/Projects/Trading-Signals/NT/Modules/ClientInterface.js
+++ b/Projects/Trading-Signals/NT/Modules/ClientInterface.js
@@ -162,7 +162,7 @@ exports.newTradingSignalsModulesClientInterface = function newTradingSignalsModu
             Broadcast the Signal to all clients connected to this Network Node.
             */
             let response
-            if (await NT.networkApp.webSocketsInterface.socketInterfaces.broadcastSignalsToClients(socketMessage, sendingBot) !== true) {
+            if (await NT.networkApp.webSocketsInterface.socketInterfaces.broadcastSignalsToFollowers(socketMessage, sendingBot) !== true) {
                 response = {
                     result: 'Error',
                     message: 'Signal Could Not be Broadcasted to Network Clients.'

--- a/Projects/Trading-Signals/TS/Modules/OutgoingTradingSignals.js
+++ b/Projects/Trading-Signals/TS/Modules/OutgoingTradingSignals.js
@@ -1,3 +1,5 @@
+const { unique } = require("@tensorflow/tfjs-node")
+
 exports.newTradingSignalsModulesOutgoingTradingSignals = function(processIndex) {
 
     let thisObject = {
@@ -52,10 +54,11 @@ exports.newTradingSignalsModulesOutgoingTradingSignals = function(processIndex) 
             /*
             This is the signal message we are going to send.
             */
+            const now = new Date()
             let tradingSignalMessage = {
                 tradingSignal: {
                     uniqueId: SA.projects.foundations.utilities.miscellaneousFunctions.genereteUniqueId(),
-                    timestamp: (new Date()).valueOf(),
+                    timestamp: now.valueOf(),
                     source: {
                         tradingSystem: {
                             node: {
@@ -87,6 +90,10 @@ exports.newTradingSignalsModulesOutgoingTradingSignals = function(processIndex) 
                 return
             }
             TS.projects.foundations.globals.taskConstants.TRADING_SIGNALS.outgoingCandleSignals.broadcastSignal(tradingSignalMessage, socialTradingBot)
+            /* Update task status with progress message */
+            let UTCtime = now.toISOString().split(/T/)[1]
+            UTCtime = UTCtime.split(/\./).shift() + " UTC"
+            TS.projects.foundations.functionLibraries.taskFunctions.taskHearBeat("Signal broadcasted at " + UTCtime, false)
         }
     }
 }

--- a/Projects/Trading-Signals/TS/Modules/OutgoingTradingSignals.js
+++ b/Projects/Trading-Signals/TS/Modules/OutgoingTradingSignals.js
@@ -1,5 +1,3 @@
-const { unique } = require("@tensorflow/tfjs-node")
-
 exports.newTradingSignalsModulesOutgoingTradingSignals = function(processIndex) {
 
     let thisObject = {


### PR DESCRIPTION
This change completes the transition to the requirement of allocating Token Power for following signals. Users not having established a follower relationship by adding a "Followed Bot Reference" node will be cut off from signal receipt.