### PR TITLE
Update TaskServer vscode debug configuration

### DIFF
--- a/TaskServer/.vscode/launch.json
+++ b/TaskServer/.vscode/launch.json
@@ -8,6 +8,7 @@
             "type": "node",
             "request": "launch",
             "name": "Launch Program on Linux",
+            "args": "vsCodeDebug",
             "skipFiles": [
                 "<node_internals>/**"
             ],
@@ -17,6 +18,7 @@
             "type": "node",
             "request": "launch",
             "name": "Launch Program on Windows",
+            "args": "vsCodeDebug",
             "skipFiles": [
                 "<node_internals>/**"
             ],


### PR DESCRIPTION
Added a "vsCodeDebug" argument so that debug config doesn't break with latest changes on launch scripts