### PR TITLE
Network node now resets connections every 1hr

### DIFF
--- a/Projects/Network/NT/Modules/WebSocketsInterface.js
+++ b/Projects/Network/NT/Modules/WebSocketsInterface.js
@@ -54,6 +54,9 @@ exports.newNetworkModulesWebSocketsInterface = function newNetworkModulesWebSock
                 caller.socket.id = SA.projects.foundations.utilities.miscellaneousFunctions.genereteUniqueId()
                 caller.socket.on('close', onConnectionClosed)
 
+                // Refresh all connections every 1hr.
+                setTimeout(refreshConnections, 3600000);
+
                 /* Active bi-directional heartbeat of the websockets connection to detect and handle hidden connection drops */
                 caller.socket.isAlive = true
                 caller.socket.on('pong', heartbeat)
@@ -91,7 +94,17 @@ exports.newNetworkModulesWebSocketsInterface = function newNetworkModulesWebSock
                     let socketId = this.id
                     thisObject.socketInterfaces.onConnectionClosed(socketId)
                 }
+
+                // Terminate Connection on server side so client side can reconnect.
+                function refreshConnections() {
+                    clearInterval(interval)
+                    return caller.socket.terminate()
+                }
             }
+
+
+            
+
         } catch (err) {
             SA.logger.error('Web Sockets Interface -> setUpWebSocketServer -> err.stack = ' + err.stack)
         }


### PR DESCRIPTION
Sending this as a stand alone contribution. Tested working only using network node and social trading app. No testing on trading signals has been done. 

This update now makes the network node reset each connection every 1hr. This is done by terminating the connection on the server side causing the client side to immediately reconnect.

This should help with the stability of our connections used for trading signals / other events that run through the network node. 