### PR TITLE
Governance: Fix for Token Power calculation

### DIFF
--- a/Projects/Governance/UI/Function-Libraries/VotingProgram.js
+++ b/Projects/Governance/UI/Function-Libraries/VotingProgram.js
@@ -208,7 +208,6 @@ function newGovernanceFunctionLibraryVotingProgram() {
                 if (node.payload.votingProgram === undefined) { return }
 
                 node.payload.votingProgram.votes = node.payload.votingProgram.votes + votes
-                node.payload.tokenPower = node.payload.votingProgram.votes
 
                 if (node.type === 'Voting Program') {
                     node.payload.votingProgram.incomingPower = node.payload.votingProgram.votes - node.payload.votingProgram.ownPower


### PR DESCRIPTION
Fixing issue introduced with PR #4804 which set Token Power equal to Voting Power. This leads to issues, particularly in cases when users receive delegated voting power.

One of the symptoms of this issue were negative delegated token powers displayed under Reporting / Profiles / Delegated Power.