### PR TITLE
Contribution: Education: Polus docs repaginated to remove error at startup

### DIFF
--- a/Platform/Client/Http-Routes/docs.js
+++ b/Platform/Client/Http-Routes/docs.js
@@ -339,6 +339,13 @@ exports.newDocsRoute = function newDocsRoute() {
                     .replace('..', '.')
                     .replace(',', '')
                     .replace('\'', '')
+                    .replace(':', '')
+                    .replace('|', '')
+                    .replace('"', '')
+                    .replace('<', '')
+                    .replace('>', '')
+                    .replace(';', '')
+                    .replace('=', '')
             }
             return fileName
         }

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-001-polus-by-@raplh2502-.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-001-polus-by-@raplh2502-.json
@@ -1,6 +1,6 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "1",
+    "pageNumber": 1,
     "type": "Polus by @Raplh2502 ",
     "definition": {
         "text": "The Polus Data Mine features several indicators as listed below. These indicator's parameters can be adjusted at the Indicator Bot Instance under the applicable Data Mining Task Node.",

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-002-fisher-MFI.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-002-fisher-MFI.json
@@ -1,6 +1,6 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "2",
+    "pageNumber": 2,
     "type": "Fisher MFI",
     "definition": {
         "text": "The Fisher MFI - this indicator normalizes price and volume action into a gaussian normal disctibution. This version of the Fisher Transform uses money flow index (MFI) as a base of calculations instead of just the price action.",

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-003-monte-carlo-forecast.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-003-monte-carlo-forecast.json
@@ -1,6 +1,6 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "3",
+    "pageNumber": 3,
     "type": "Monte Carlo Forecast",
     "definition": {
         "text": "The Monte-Carlo simulation is an algorithmic method used to approximate a numerical value with random processes.",

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-004-keltner-channel-mama-version.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-004-keltner-channel-mama-version.json
@@ -1,6 +1,6 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "5",
+    "pageNumber": 4,
     "type": "Keltner Channel - MAMA version",
     "definition": {
         "text": "Keltner channel using Mesa Adaptive Moving Average (MAMA).",

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-005-keltner-channel-ema-version.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-005-keltner-channel-ema-version.json
@@ -1,6 +1,6 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "6",
+    "pageNumber": 5,
     "type": "Keltner Channel - EMA version",
     "definition": {
         "text": "Keltner Channel using Exponential Moving Average (EMA).",

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-006-one-minute-counter.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-006-one-minute-counter.json
@@ -1,6 +1,6 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "7",
+    "pageNumber": 6,
     "type": "One Minute counter",
     "definition": {
         "text": "This indicator provides a simple counter that counts from 0 to 59 to represent every minute of the hour.",

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-007-volatility-index.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-007-volatility-index.json
@@ -1,6 +1,6 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "8",
+    "pageNumber": 7,
     "type": "Volatility Index",
     "definition": {
         "text": "The Volatility Index represents how an asset's prices moves around the calculated mean price.",

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-008-volatility-oscillator.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-008-volatility-oscillator.json
@@ -1,6 +1,6 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "9",
+    "pageNumber": 8,
     "type": "Volatility Oscillator",
     "definition": {
         "text": "The Weighted Volatility Oscillator is a modification of the standard volatility index but weighted by the position of the price in the Bollinger Band.",

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-009-volatility-adjusted-moving-average.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-009-volatility-adjusted-moving-average.json
@@ -1,6 +1,6 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "10",
+    "pageNumber": 9,
     "type": "Volatility Adjusted Moving Average",
     "definition": {
         "text": "The Volatility Adjusted Moving Average (VAMA) is an indicator that takes into account both short and long term volatility. It creates a moving average that attempts to gauge an area of price action that is expected to produce a reaction when interacting with it.",

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-010-relative-vigor-index.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-010-relative-vigor-index.json
@@ -1,6 +1,6 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "11",
+    "pageNumber": 10,
     "type": "Relative Vigor Index",
     "definition": {
         "text": "The Relative Vigor Index (RVI) is a momentum indicator similar to the Stochastic indicator. The RVI compares candle open and closes to determine the output trend, instead of the Stochastic's comparison of a candle's close to minimum.",

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-011-volatility-bands.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-011-volatility-bands.json
@@ -1,6 +1,6 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "12",
+    "pageNumber": 11,
     "type": "Volatility Bands",
     "definition": {
         "text": "Volatility Bands take a Volatility Adjusted Moving Average (VAMA) to produce bands similar to Bollinger Bands and the Keltner channel.",

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-012-ehlers-signal-to-noise-ratio.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-012-ehlers-signal-to-noise-ratio.json
@@ -1,6 +1,6 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "13",
+    "pageNumber": 12,
     "type": "Ehlers Signal-to-noise Ratio",
     "definition": {
         "text": "This is a volatility indicator created by John Ehlers and published in his book ’Rocket Science for Traders, p81-82.’",

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-013-price-probabilities.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-013-price-probabilities.json
@@ -1,6 +1,6 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "14",
+    "pageNumber": 13,
     "type": "Price Probabilities",
     "definition": {
         "text": "This is an indicator that uses Exponential Moving Average (EMA) and Average True Range (ATR) to provide probability bands around the price action based on standard deviations.",

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-014-probabilities-periodic-return-sigma.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-014-probabilities-periodic-return-sigma.json
@@ -1,7 +1,7 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "15",
-    "type": "Probabilities: Periodic Return Sigma",
+    "pageNumber": 14,
+    "type": "Probabilities - Periodic Return Sigma",
     "definition": {
         "text": "This is an indicator that uses the historical volatility to predict price action in the future using a Periodic Return (PR) calculation and a Moving Average (MA) of 200 periods."
     },
@@ -9,36 +9,36 @@
         {
             "style": "Title",
             "text": "Periodic Return Sigma on the Charts"
-        }, 
+        },
         {
             "style": "Text",
             "text": "This indicator produces an output value, Z, by calculating the periodic return, the 200MA and the sigma (standard deviation) value."
-        }, 
-		{
+        },
+        {
             "style": "List",
             "text": "Periodic Return (PR): this is calculated by taking the natural logarithm of the ratio of candle close divided by the previous candle close: ln(candle.close/candle.previous.close)"
         },
-		{
+        {
             "style": "List",
             "text": "Sigma: The sigma value is calculated by finding the standard deviation of the past price action (defaulting to 200 periods)."
-        }, 
-		{
+        },
+        {
             "style": "List",
             "text": "Z Value: The z value is then calculated by finding the difference between the Periodic Return and the 200MA, then dividing result by the sigma value: z = (PR - MA) / sigma"
-        },    
-		{
+        },
+        {
             "style": "Png",
             "text": "PNGs/Foundations/Docs/indicators/Polus-Probability-Periodic-return.png"
         },
-		{
+        {
             "style": "Text",
-            "text": "The length of the calculation can be changed by locating and opening the Javascript Code under Data Building Procedure -> Procedure Loop under \u2019Periodic_Return_Sigma_Probabilities\u2019 Product Definition."
+            "text": "The length of the calculation can be changed by locating and opening the Javascript Code under Data Building Procedure -> Procedure Loop under ’Periodic_Return_Sigma_Probabilities’ Product Definition."
         },
         {
             "style": "Png",
             "text": "PNGs/Foundations/Docs/indicators/Polus-Probability-Periodic-return-params.png"
         },
-		{
+        {
             "style": "Title",
             "text": "Products & Properties"
         },
@@ -50,15 +50,15 @@
             "style": "Table",
             "text": "| Product Name | Product Variable | Properties |\n| Periodic_Return_Sigma_Probabilities | PRSP | Z |"
         },
-		{
+        {
             "style": "Text",
             "text": "Example:"
         },
-		{
+        {
             "style": "Text",
             "text": "A simple buy signal could be triggered when the signal line crosses the red -2.34 line from below:"
         },
-		{
+        {
             "style": "Javascript",
             "text": "chart.at01hs.PRSP.previous.Z < -2.34 && chart.at01hs.PRSP.Z > -2.34"
         },

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-015-probabilities-sigma.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-015-probabilities-sigma.json
@@ -1,7 +1,7 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "16",
-    "type": "Probabilities: Sigma",
+    "pageNumber": 15,
+    "type": "Probabilities - Sigma",
     "definition": {
         "text": "This is an indicator that uses the Typical Price (TP), Moving Average (MA) of 200 periods and Standard Deviation to calculate it's output value."
     },
@@ -9,36 +9,36 @@
         {
             "style": "Title",
             "text": "Sigma on the Charts"
-        }, 
+        },
         {
             "style": "Text",
             "text": "This indicator produces an output value, Z, by using the Typical Price, the 200MA and the sigma (standard deviation) value."
-        }, 
-		{
+        },
+        {
             "style": "List",
             "text": "Typical Price: this is calculated using the following formula: (candle.max + candle.min + candle.close) / 3 "
         },
-		{
+        {
             "style": "List",
             "text": "Sigma: The sigma value is calculated by finding the standard deviation of the past price action (defaulting to 200 periods)."
-        }, 
-		{
+        },
+        {
             "style": "List",
             "text": "Z Value: The z value is then calculated by finding the difference between the current candle.close and the 200MA, then dividing result by the sigma value: z = (TP - MA) / sigma"
-        },    
-		{
+        },
+        {
             "style": "Png",
             "text": "PNGs/Foundations/Docs/indicators/Polus-Probability-Sigma.png"
         },
-		{
+        {
             "style": "Text",
-            "text": "The length of the calculation can be changed by locating and opening the Javascript Code under Data Building Procedure -> Procedure Loop under \u2019Sigma_Probabilities\u2019 Product Definition."
+            "text": "The length of the calculation can be changed by locating and opening the Javascript Code under Data Building Procedure -> Procedure Loop under ’Sigma_Probabilities’ Product Definition."
         },
         {
             "style": "Png",
             "text": "PNGs/Foundations/Docs/indicators/Polus-Probability-Periodic-return-params.png"
         },
-		{
+        {
             "style": "Title",
             "text": "Products & Properties"
         },
@@ -50,15 +50,15 @@
             "style": "Table",
             "text": "| Product Name | Product Variable | Properties |\n| Sigma_Probabilities | ProdSigma | Z |"
         },
-		{
+        {
             "style": "Text",
             "text": "Example:"
         },
-		{
+        {
             "style": "Text",
             "text": "A simple buy signal could be triggered when the signal line crosses the red -2.34 line from below:"
         },
-		{
+        {
             "style": "Javascript",
             "text": "chart.at01hs.ProdSigma.previous.Z < -2.34 && chart.at01hs.ProdSigma.Z > -2.34"
         },

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-016-probabilities-return.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-016-probabilities-return.json
@@ -1,7 +1,7 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "17",
-    "type": "Probabilities: Return",
+    "pageNumber": 16,
+    "type": "Probabilities - Return",
     "definition": {
         "text": "This is an indicator that uses the Periodic Return (PR), a Moving Average (MA) of 200 periods and Standard Deviation to calculate probabilities of future price action."
     },
@@ -9,36 +9,36 @@
         {
             "style": "Title",
             "text": "Return on the Charts"
-        }, 
+        },
         {
             "style": "Text",
             "text": "This indicator produces multiple output values by calculating the periodic return, the 200MA and the sigma (standard deviation) value:"
-        }, 
-		{
+        },
+        {
             "style": "List",
             "text": "Periodic Return (PR): this is calculated by taking the natural logarithm of the ratio of candle close divided by the previous candle close: ln(candle.close/candle.previous.close)"
         },
-		{
+        {
             "style": "List",
-			"text": "UpValues: A series of probability points based on the MA value added to the sigma multiplied by a standard deviation factor of 0.53, 1.03, 2.34, 2.95 and 4.87 to get HP30, HP15, HP1, HP02 and HP01 respectively."
-        }, 
-		{
+            "text": "UpValues: A series of probability points based on the MA value added to the sigma multiplied by a standard deviation factor of 0.53, 1.03, 2.34, 2.95 and 4.87 to get HP30, HP15, HP1, HP02 and HP01 respectively."
+        },
+        {
             "style": "List",
             "text": "Down Values: A series of probability points based on the MA subtracted by the sigma value multiplied by a standard deviation factor of 0.53, 1.03, 2.34, 2.95 and 4.87 to get LP30, LP15, LP1, LP02 and LP01 respectively."
-        },    
-		{
+        },
+        {
             "style": "Png",
             "text": "PNGs/Foundations/Docs/indicators/Polus-Probability-Return.png"
         },
-		{
+        {
             "style": "Text",
-            "text": "The length of the calculation can be changed by locating and opening the Javascript Code under Data Building Procedure -> Procedure Loop under \u2019Return probabilities\u2019 Product Definition."
+            "text": "The length of the calculation can be changed by locating and opening the Javascript Code under Data Building Procedure -> Procedure Loop under ’Return probabilities’ Product Definition."
         },
         {
             "style": "Png",
             "text": "PNGs/Foundations/Docs/indicators/Polus-Probability-Return-params.png"
         },
-		{
+        {
             "style": "Title",
             "text": "Products & Properties"
         },
@@ -50,15 +50,15 @@
             "style": "Table",
             "text": "| Product Name | Product Variable | Properties |\n| Return probabilities | RPB | pr, l01, l02, l1, l15, l30, h01, h02, h1, h15, h30 |"
         },
-		{
+        {
             "style": "Text",
             "text": "Example:"
         },
-		{
+        {
             "style": "Text",
             "text": "Examples of accessing this indicator can be found below:"
         },
-		{
+        {
             "style": "Javascript",
             "text": "chart.at01hs.RPB.pr \n chart.at01hs.RPB.l02 \n chart.at01hs.RPB.l15 \n chart.at01hs.RPB.h01 \n chart.at01hs.RPB.h1 \n chart.at01hs.RPB.h15"
         },

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-017-probabilities-min-sigma.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-017-probabilities-min-sigma.json
@@ -1,7 +1,7 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "18",
-    "type": "Probabilities: Min Sigma",
+    "pageNumber": 17,
+    "type": "Probabilities - Min Sigma",
     "definition": {
         "text": "This is an indicator that uses the candle minimum, a Moving Average (MA) of 20 periods and Standard Deviation to calculate it's output value."
     },
@@ -9,28 +9,28 @@
         {
             "style": "Title",
             "text": "Min Sigma on the Charts"
-        }, 
+        },
         {
             "style": "Text",
             "text": "This indicator produces an output value, Z, by using the a 20MA, the sigma (standard deviation) value: Z = (candle.min - 20MA) / sigma"
-        }, 
-		{
+        },
+        {
             "style": "Text",
             "text": "A strike value is also available, which could be used as a trailing stop loss."
-        },   
-		{
+        },
+        {
             "style": "Png",
             "text": "PNGs/Foundations/Docs/indicators/Polus-Probability-Min-Sigma.png"
         },
-		{
+        {
             "style": "Text",
-            "text": "The length of the calculation can be changed by locating and opening the Javascript Code under Data Building Procedure -> Procedure Loop under \u2019SMin sigma probability\u2019 Product Definition."
+            "text": "The length of the calculation can be changed by locating and opening the Javascript Code under Data Building Procedure -> Procedure Loop under ’SMin sigma probability’ Product Definition."
         },
         {
             "style": "Png",
             "text": "PNGs/Foundations/Docs/indicators/Polus-Probability-Min-Sigma-params.png"
         },
-		{
+        {
             "style": "Title",
             "text": "Products & Properties"
         },
@@ -42,19 +42,19 @@
             "style": "Table",
             "text": "| Product Name | Product Variable | Properties |\n| Min sigma probability | Min_Sigma | Z, strike |"
         },
-		{
+        {
             "style": "Text",
             "text": "Example:"
         },
-		{
+        {
             "style": "Text",
             "text": "A simple buy signal could be triggered when the signal line crosses the red -2.34 line from below:"
         },
-		{
+        {
             "style": "Javascript",
             "text": "chart.at01hs.Min_Sigma.previous.Z < -2.34 && chart.at01hs.Min_Sigma.Z > -2.34"
         },
-		{
+        {
             "style": "Javascript",
             "text": "\\\\stop loss value\nchart.at01hs.Min_Sigma.strike"
         },

--- a/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-018-probabilities-max-sigma.json
+++ b/Projects/Foundations/Schemas/Docs-Topics/P/Polus/Polus-Data-Mine/polus-data-mine-018-probabilities-max-sigma.json
@@ -1,7 +1,7 @@
 {
     "topic": "Polus Data Mine",
-    "pageNumber": "19",
-    "type": "Probabilities: Max Sigma",
+    "pageNumber": 18,
+    "type": "Probabilities - Max Sigma",
     "definition": {
         "text": "This is an indicator that uses the candle maximum, a Moving Average (MA) of 200 periods and Standard Deviation (sigma) to calculate it's output value."
     },
@@ -9,28 +9,28 @@
         {
             "style": "Title",
             "text": "Max Sigma on the Charts"
-        }, 
+        },
         {
             "style": "Text",
             "text": "This indicator produces an output value, Z, by using the a 200MA, the sigma (standard deviation) value: Z = (Return - 200MA) / sigma"
-        }, 
-		{
+        },
+        {
             "style": "List",
-            "text": "Return: the natural log of candle.max / candle.previous.min"			
-        },   
-		{
+            "text": "Return: the natural log of candle.max / candle.previous.min"
+        },
+        {
             "style": "Png",
             "text": "PNGs/Foundations/Docs/indicators/Polus-Probability-Max-Sigma.png"
         },
-		{
+        {
             "style": "Text",
-            "text": "The length of the calculation can be changed by locating and opening the Javascript Code under Data Building Procedure -> Procedure Loop under \u2019SR max sigma probability\u2019 Product Definition."
+            "text": "The length of the calculation can be changed by locating and opening the Javascript Code under Data Building Procedure -> Procedure Loop under ’SR max sigma probability’ Product Definition."
         },
         {
             "style": "Png",
             "text": "PNGs/Foundations/Docs/indicators/Polus-Probability-Max-Sigma-params.png"
         },
-		{
+        {
             "style": "Title",
             "text": "Products & Properties"
         },
@@ -42,15 +42,15 @@
             "style": "Table",
             "text": "| Product Name | Product Variable | Properties |\n| R max sigma probability | RMax | Z |"
         },
-		{
+        {
             "style": "Text",
             "text": "Example:"
         },
-		{
+        {
             "style": "Text",
             "text": "Accessing the data for this indicator is shown below:"
         },
-		{
+        {
             "style": "Javascript",
             "text": "chart.at01hs.RMax.Z"
         },


### PR DESCRIPTION
This PR removes an error about unexpectedly ending JSON files (Docs from the Polus Data Mine) which was displayed when starting SA.

The root cause of this error was the docs logic including characters which are not allowed on some operating systems - in this case a colon (:) - to the names of JSON files written to disk. The character filtering logic is now extended by several further problematic characters.