### PR TITLE
Fixed Discord bot's initialization error.

### DIFF
--- a/Projects/Social-Bots/SA/Bot-Modules/DiscordBot.js
+++ b/Projects/Social-Bots/SA/Bot-Modules/DiscordBot.js
@@ -14,9 +14,9 @@ exports.newSocialBotsBotModulesDiscordBot = function () {
 
     async function initialize(config) {
         /* Discord Bot Initialization */
-        const { Client, Intents } = SA.nodeModules.discordjs
+        const { Client, GatewayIntentBits } = SA.nodeModules.discordjs
 
-        const client = new Client({ intents: [Intents.FLAGS.GUILDS] })
+        const client = new Client({ intents: [GatewayIntentBits.Guilds] })
         thisObject.discordClient = client
 
         token = config.token


### PR DESCRIPTION
Discord bot was not being initialized due to discordjs not using "Flags" but rather "GatewayIntentBits".