### PR TITLE
Refactoring of version check for node/npm/git

### DIFF
--- a/Launch-Scripts/systemCheck.js
+++ b/Launch-Scripts/systemCheck.js
@@ -78,7 +78,7 @@ function compareVersions(actualVersion, neededVersion, application) {
   
   while (continueCheck) {
     /* End check as successful if next part of version number is undefined */
-    if (typeof actualVersion[pos] === undefined || typeof neededVersion[pos] === undefined || !actualVersion[pos] || !neededVersion[pos]) {
+    if (typeof actualVersion[pos] === 'undefined' || typeof neededVersion[pos] === 'undefined' || !actualVersion[pos] || !neededVersion[pos]) {
       continueCheck = false
       /* Output warning message if main version of an application can not be obtained */
       if (pos === 0) {

--- a/Launch-Scripts/systemCheck.js
+++ b/Launch-Scripts/systemCheck.js
@@ -1,8 +1,6 @@
 const { execSync } = require("child_process")
 const os = require("os")
 const env = require("../Environment").newEnvironment()
-const semver = require('semver')
-//const semver = require('semver/classes/comparator')
 
 // moved 'minimum versions required' to environment file, this 
 // centralizes them in one place & makes tests more robust
@@ -12,34 +10,34 @@ const semver = require('semver')
 function systemCheck () {
   try {
     
-    // Gather Installed Versions of Node, NPM and Git
-    const npmVersion = execSync( "npm -v").toString().trim()
-    const nodeVersion = execSync( "node -v").toString().trim()
-    const gitVersion = execSync( "git --version").toString().split(' ')[2].trim()
+    // Gather installed versions of Node, NPM and Git
+    const npmVersionRaw = execSync( "npm -v",{ encoding: 'utf8', timeout: 30000 })
+    const nodeVersionRaw = execSync( "node -v",{ encoding: 'utf8',timeout: 30000 })
+    const gitVersionRaw = execSync( "git --version",{ encoding: 'utf8',timeout: 30000 })
+    const npmVersionStrArray = npmVersionRaw.trim().split('.')
+    const nodeVersionStrArray = nodeVersionRaw.trim().substring(1).split('.')
+    const gitVersionStrArray = gitVersionRaw.trim().split(' ')[2].split('.')
+    /* Gather required versions of Node, NPM and Git from Environment.js */
+    const npmNeededVersionStrArray = env.NPM_NEEDED_VERSION.trim().split('.')
+    const nodeNeededVersionStrArray = env.NODE_NEEDED_VERSION.trim().split('.')
+    const gitNeededVersionStrArray = env.GIT_NEEDED_VERSION.trim().split('.')
+    /* Convert version strings into integers */
+    const npmVersion = parseArrayToInt(npmVersionStrArray)
+    const nodeVersion = parseArrayToInt(nodeVersionStrArray)
+    const gitVersion = parseArrayToInt(gitVersionStrArray)
+    const npmNeededVersion = parseArrayToInt(npmNeededVersionStrArray)
+    const nodeNeededVersion = parseArrayToInt(nodeNeededVersionStrArray)
+    const gitNeededVersion = parseArrayToInt(gitNeededVersionStrArray)
 
-    // Make sure update version of npm is installed
-      if (semver.compare(npmVersion,env.NPM_NEEDED_VERSION) < 0) {
-      console.log('')
-      console.log("ERROR: the version of npm V",npmVersion, " you have installed is out of date. Please update your installation of npm and try again.")
-      console.log('')
-      process.exit()
-    }
+    // Make sure required version of npm is installed
+    compareVersions(npmVersion, npmNeededVersion, "npm")
     
-    // Make sure update version of node is installed 
-      if (semver.compare(nodeVersion,env.NODE_NEEDED_VERSION) < 0) {
-      console.log('')
-      console.log("ERROR: the version of node V",nodeVersion, "you have installed is out of date. Please update your installation of node and try again.")
-      console.log('')
-      process.exit()
-    }
+    // Make sure required version of node is installed 
+    compareVersions(nodeVersion, nodeNeededVersion, "node")
 
-    // Make sure updated version of git is installed
-      if (semver.compare(gitVersion,env.GIT_NEEDED_VERSION) < 0) {
-      console.log('')
-      console.log("ERROR: the version of git V",gitVersion, "you have installed is out of date. Please update your installation of git and try again.")
-      console.log('')
-      process.exit()
-    }
+    // Make sure required version of git is installed
+    compareVersions(gitVersion, gitNeededVersion, "git")
+
 
     // Check windows system
     // console.log(os.platform())
@@ -66,6 +64,45 @@ function systemCheck () {
   }
   return true
 
+}
+
+function parseArrayToInt(array) {
+  return array.map(function(item) {
+    return parseInt(item, 10)
+  })
+}
+
+function compareVersions(actualVersion, neededVersion, application) {
+  let pos = 0
+  let continueCheck = true
+  
+  while (continueCheck) {
+    /* End check as successful if next part of version number is undefined */
+    if (typeof actualVersion[pos] === undefined || typeof neededVersion[pos] === undefined || !actualVersion[pos] || !neededVersion[pos]) {
+      continueCheck = false
+      /* We must have a main version, otherwise stop with error */
+      if (pos === 0) {
+        console.log('')
+        console.log('Required or current version of ' + application + ' could not be verified. Please check your setup.')
+        console.log('')
+        process.exit()
+      }
+      break
+    /* Fail if version number is too low */
+    } else if (actualVersion[pos] < neededVersion[pos]) {
+      console.log('')
+      console.log('ERROR: the version of ' + application + ' you have installed is out of date. Please update your installation of ' + application + ' and try again.')
+      console.log('')
+      continueCheck = false
+      process.exit()    
+    /* Continue check with next segment of version number if current segment is equal */
+    } else if (actualVersion[pos] === neededVersion[pos]) {
+      pos = pos + 1
+    /* End check as successful if current version segment is higher than needed version segment */
+    } else if (actualVersion[pos] > neededVersion[pos]) {
+      continueCheck = false
+    }
+  }
 }
 
 module.exports = systemCheck

--- a/Launch-Scripts/systemCheck.js
+++ b/Launch-Scripts/systemCheck.js
@@ -80,12 +80,11 @@ function compareVersions(actualVersion, neededVersion, application) {
     /* End check as successful if next part of version number is undefined */
     if (typeof actualVersion[pos] === undefined || typeof neededVersion[pos] === undefined || !actualVersion[pos] || !neededVersion[pos]) {
       continueCheck = false
-      /* We must have a main version, otherwise stop with error */
+      /* Output warning message if main version of an application can not be obtained */
       if (pos === 0) {
         console.log('')
-        console.log('Required or current version of ' + application + ' could not be verified. Please check your setup.')
+        console.log('Warning: Unable to conduct version check for ' + application + '. If you face issues during setup, please check if this application is correctly installed on your system.') 
         console.log('')
-        process.exit()
       }
       break
     /* Fail if version number is too low */

--- a/README.md
+++ b/README.md
@@ -408,6 +408,12 @@ node \
 -v && git --version
 ```
 
+The setup process will require the presence of standard development software packages on your system, such as **make, gcc and g++**. Please monitor possible error messages during the setup process and install missing packages as required, for example:
+
+```sh
+sudo apt-get install -y make gcc g++
+```
+
 If you are running headless (i.e. as a server without a monitor attached) then you do not need to install a web browser and you can follow the tutorial for information on connecting remotely to the server.
 
 Alternatively, you can use [https://github.com/nymea/berrylan](https://github.com/nymea/berrylan) to set up a tool for using Bluetooth to quickly assign WPA2 access on a WLAN on a Raspbian-based Distro. Nymea also has tools for automation of IoT products to allow setting up Superalgos as a timed function without needing to learn how to code.


### PR DESCRIPTION
This change shall ensure a working comparison of installed vs. required version numbers during setup.

It also removes the dependency to the semver module. Usage of this module will not work with initial installs due to the module not yet present when versions are checked.