### PR TITLE
Feature/sockets debugging

### DIFF
--- a/Environment.js
+++ b/Environment.js
@@ -51,7 +51,7 @@ exports.newEnvironment = function () {
         MOBILE_APP_SIGNING_ACCOUNT: 'Social-Trading-Mobile-App-1',
         SERVER_APP_SIGNING_ACCOUNT: 'Social-Trading-Server-App-1',
         PLATFORM_APP_SIGNING_ACCOUNT: 'Algo-Traders-Platform-1',
-        P2P_NETWORK_NODE_SIGNING_ACCOUNT: 'P2P-Network-Node-1',
+        P2P_NETWORK_NODE_SIGNING_ACCOUNT: 'P2P-Local-Network-Node',
         P2P_NETWORK_NODE_MAX_INCOMING_CLIENTS: 1000,
         P2P_NETWORK_NODE_MAX_INCOMING_PEERS: 2,
         P2P_NETWORK_NODE_MAX_OUTGOING_PEERS: 2,

--- a/Environment.js
+++ b/Environment.js
@@ -51,7 +51,7 @@ exports.newEnvironment = function () {
         MOBILE_APP_SIGNING_ACCOUNT: 'Social-Trading-Mobile-App-1',
         SERVER_APP_SIGNING_ACCOUNT: 'Social-Trading-Server-App-1',
         PLATFORM_APP_SIGNING_ACCOUNT: 'Algo-Traders-Platform-1',
-        P2P_NETWORK_NODE_SIGNING_ACCOUNT: 'P2P-Local-Network-Node',
+        P2P_NETWORK_NODE_SIGNING_ACCOUNT: 'P2P-Network-Node-1',
         P2P_NETWORK_NODE_MAX_INCOMING_CLIENTS: 1000,
         P2P_NETWORK_NODE_MAX_INCOMING_PEERS: 2,
         P2P_NETWORK_NODE_MAX_OUTGOING_PEERS: 2,

--- a/NetworkRoot.js
+++ b/NetworkRoot.js
@@ -10,7 +10,7 @@ exports.newNetworkRoot = function newNetworkRoot() {
 
     return thisObject
 
-    async function run(debugSettings) {
+    async function run(debugSettings, networkFilters) {
         /* 
         The NT object is accessible everywhere at the Superalgos Network.
         It provides access to all modules built for this Network.
@@ -20,7 +20,7 @@ exports.newNetworkRoot = function newNetworkRoot() {
         The SA object is accessible everywhere at the Superalgos Network.
         It provides access to all modules built for Superalgos in general.
         */
-        global.SA = {}
+        global.SA = {networkFilters}
         /* Load Environment Variables */
         let ENVIRONMENT = require('./Environment.js');
         let ENVIRONMENT_MODULE = ENVIRONMENT.newEnvironment()

--- a/NetworkRoot.js
+++ b/NetworkRoot.js
@@ -61,9 +61,7 @@ exports.newNetworkRoot = function newNetworkRoot() {
         SA.version = require('./package.json').version
 
         const saLogsPath = SA.nodeModules.path.join(global.env.PATH_TO_LOG_FILES, 'Network')
-        const socketsLogsPath = SA.nodeModules.path.join(global.env.PATH_TO_LOG_FILES, 'NetworkSockets')
         SA.logger = require('./loggerFactory').loggerFactory(saLogsPath, 'NT')
-        SA.socketLogger = require('./loggerFactory').loggerFactory(socketsLogsPath, 'NT')
 
         /* 
         Setting up the App Schema Memory Map. 

--- a/NetworkRoot.js
+++ b/NetworkRoot.js
@@ -10,7 +10,7 @@ exports.newNetworkRoot = function newNetworkRoot() {
 
     return thisObject
 
-    async function run(debugSettings) {
+    async function run(debugSettings, networkFilters) {
         /* 
         The NT object is accessible everywhere at the Superalgos Network.
         It provides access to all modules built for this Network.
@@ -20,7 +20,7 @@ exports.newNetworkRoot = function newNetworkRoot() {
         The SA object is accessible everywhere at the Superalgos Network.
         It provides access to all modules built for Superalgos in general.
         */
-        global.SA = {}
+        global.SA = {networkFilters}
         /* Load Environment Variables */
         let ENVIRONMENT = require('./Environment.js');
         let ENVIRONMENT_MODULE = ENVIRONMENT.newEnvironment()
@@ -61,7 +61,9 @@ exports.newNetworkRoot = function newNetworkRoot() {
         SA.version = require('./package.json').version
 
         const saLogsPath = SA.nodeModules.path.join(global.env.PATH_TO_LOG_FILES, 'Network')
+        const socketsLogsPath = SA.nodeModules.path.join(global.env.PATH_TO_LOG_FILES, 'NetworkSockets')
         SA.logger = require('./loggerFactory').loggerFactory(saLogsPath, 'NT')
+        SA.socketLogger = require('./loggerFactory').loggerFactory(socketsLogsPath, 'NT')
 
         /* 
         Setting up the App Schema Memory Map. 

--- a/Projects/Network/NT/Modules/WebSocketsInterface.js
+++ b/Projects/Network/NT/Modules/WebSocketsInterface.js
@@ -75,10 +75,7 @@ exports.newNetworkModulesWebSocketsInterface = function newNetworkModulesWebSock
              * interval the client will be removed from all lists and
              * the connection terminated.
              */
-            interval = setInterval(ping(), 30000)
-
-            function ping() {
-                SA.logger.debug(`Number of websocket clients: ${clients.size}`);
+            interval = setInterval(function ping() {
                 [...clients.keys()].forEach(socket => {
                     const client = clients.get(socket);
                     if(!client.isAlive) {
@@ -92,7 +89,7 @@ exports.newNetworkModulesWebSocketsInterface = function newNetworkModulesWebSock
                     client.isAlive = false
                     socket.ping()
                 })
-            }
+            }, 30000)
 
             /**
              * This function is executed every time a new Websockets connection

--- a/Projects/Network/NT/Modules/WebSocketsInterface.js
+++ b/Projects/Network/NT/Modules/WebSocketsInterface.js
@@ -75,7 +75,10 @@ exports.newNetworkModulesWebSocketsInterface = function newNetworkModulesWebSock
              * interval the client will be removed from all lists and
              * the connection terminated.
              */
-            interval = setInterval(function ping() {
+            interval = setInterval(ping(), 30000)
+
+            function ping() {
+                SA.logger.debug(`Number of websocket clients: ${clients.size}`);
                 [...clients.keys()].forEach(socket => {
                     const client = clients.get(socket);
                     if(!client.isAlive) {
@@ -89,7 +92,7 @@ exports.newNetworkModulesWebSocketsInterface = function newNetworkModulesWebSock
                     client.isAlive = false
                     socket.ping()
                 })
-            }, 30000)
+            }
 
             /**
              * This function is executed every time a new Websockets connection

--- a/Projects/Network/NT/Modules/WebSocketsInterface.js
+++ b/Projects/Network/NT/Modules/WebSocketsInterface.js
@@ -1,5 +1,3 @@
-const { SlashCommandBooleanOption } = require("discord.js");
-
 /**
  * This module represents the websockets interface of the Network Node.
  *

--- a/Projects/Network/NT/Modules/WebSocketsInterface.js
+++ b/Projects/Network/NT/Modules/WebSocketsInterface.js
@@ -1,3 +1,5 @@
+const { SlashCommandBooleanOption } = require("discord.js");
+
 /**
  * This module represents the websockets interface of the Network Node.
  *
@@ -76,17 +78,15 @@ exports.newNetworkModulesWebSocketsInterface = function newNetworkModulesWebSock
              * the connection terminated.
              */
             interval = setInterval(function ping() {
-                SA.socketLogger.info(`Number of websocket clients: ${clients.size}`);
                 [...clients.keys()].forEach(socket => {
                     const client = clients.get(socket);
                     if(!client.isAlive) {
-                        // SA.socketLogger.info('Server could not confirm client to be alive, terminating Websockets connection for ' + tailLogInfo(client))
+                        SA.logger.debug('Server could not confirm client to be alive, terminating Websockets connection for ' + tailLogInfo(client))
                         thisObject.socketInterfaces.onConnectionClosed(client.id)
                         socket.terminate()
                         clients.delete(socket)
                         return
                     }
-                    // SA.socketLogger.info('Server-side heart beat pinged for ' + tailLogInfo(client))
                     client.isAlive = false
                     socket.ping()
                 })
@@ -99,7 +99,6 @@ exports.newNetworkModulesWebSocketsInterface = function newNetworkModulesWebSock
              * @param {WebSocket} socket
              */
             function onConnectionOpened(socket, req) {
-                const ip = req.socket.remoteAddress;
                 socket.id = SA.projects.foundations.utilities.miscellaneousFunctions.genereteUniqueId()
 
                 /** @type {Caller} */ let caller = {
@@ -111,7 +110,6 @@ exports.newNetworkModulesWebSocketsInterface = function newNetworkModulesWebSock
                     role: undefined
                 }
                 clients.set(socket, caller);
-                SA.socketLogger.info('Added new caller to network client list ' + caller.id + ' from IP ' + ip)
 
                 caller.socket.on('close', onConnectionClosed)
 
@@ -131,18 +129,15 @@ exports.newNetworkModulesWebSocketsInterface = function newNetworkModulesWebSock
 
                 function heartbeat() {
                     caller.isAlive = true
-                    SA.socketLogger.info('Incoming Pong received for ' + tailLogInfo(caller))
                 }
 
                 function onConnectionClosed() {
-                    SA.socketLogger.info('Closing socket for ' + tailLogInfo(caller))
                     thisObject.socketInterfaces.onConnectionClosed(caller.id)
-                    SA.socketLogger.info('Deleting socket client for ' + tailLogInfo(caller))
                     clients.delete(socket)
                 }
             }
         } catch (err) {
-            SA.socketLogger.error('Web Sockets Interface -> setUpWebSocketServer -> err.stack = ' + err.stack)
+            SA.logger.error('Web Sockets Interface -> setUpWebSocketServer -> err.stack = ' + err.stack)
         }
 
         /**

--- a/Projects/Network/SA/Modules/P2PNetworkNodesConnectedTo.js
+++ b/Projects/Network/SA/Modules/P2PNetworkNodesConnectedTo.js
@@ -165,7 +165,7 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
                 }
             }
             while (disconnectedPeers.length > 0) {
-                let peer = disconnectedPeer.unshift()
+                let peer = disconnectedPeers.unshift()
                 thisObject.peers.splice(peer, 1)
             }
         }

--- a/Projects/Network/SA/Modules/P2PNetworkNodesConnectedTo.js
+++ b/Projects/Network/SA/Modules/P2PNetworkNodesConnectedTo.js
@@ -49,6 +49,13 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
         async function connectToPeers() {
             // logPeers()
             if (thisObject.peers.length >= maxOutgoingPeers) {
+                checkConnectedPeers()
+                if(thisObject.peers.length >= maxOutgoingPeers) {
+                    const itemsToPrune = thisObject.peers.splice(0, maxOutgoingPeers)
+                    for(let i = 0; i < itemsToPrune.length; i++) {
+                        itemsToPrune[i].webSocketsClient.finalize()
+                    }
+                }
                 intervalIdConnectToPeers = setTimeout(connectToPeers, RECONNECT_DELAY)
                 return
             }
@@ -154,7 +161,6 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
                 let peer = thisObject.peers[i]
                 if (peer.webSocketsClient.socketNetworkClients.isConnected !== true) {
                     thisObject.peers.splice(i, 1)
-                    return
                 }
             }
         }

--- a/Projects/Network/SA/Modules/P2PNetworkNodesConnectedTo.js
+++ b/Projects/Network/SA/Modules/P2PNetworkNodesConnectedTo.js
@@ -22,9 +22,9 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
     }
 
     const RECONNECT_DELAY = 10 * 1000
-    const HEALTH_CHECK_DELAY = 1 * 1000
+    //const HEALTH_CHECK_DELAY = 1 * 1000
     let intervalIdConnectToPeers
-    let intervalIdCheckConnectedToPeers
+    //let intervalIdCheckConnectedToPeers
 
     return thisObject
 

--- a/Projects/Network/SA/Modules/P2PNetworkNodesConnectedTo.js
+++ b/Projects/Network/SA/Modules/P2PNetworkNodesConnectedTo.js
@@ -164,8 +164,9 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
                     disconnectedPeers.push(i)
                 }
             }
+            //remove the items in reverse order
             while (disconnectedPeers.length > 0) {
-                let peer = disconnectedPeers.unshift()
+                let peer = disconnectedPeers.pop()
                 thisObject.peers.splice(peer, 1)
             }
         }

--- a/Projects/Network/SA/Modules/P2PNetworkNodesConnectedTo.js
+++ b/Projects/Network/SA/Modules/P2PNetworkNodesConnectedTo.js
@@ -147,10 +147,10 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
                 return `name: ${peer.p2pNetworkNode.userProfile.name}, id: ${peer.p2pNetworkNode.node.id}`
             }
             
-            function logPeers() {
-                const output = thisObject.peers.length == 0 ? '[]' : '[\n' + thisObject.peers.map(p => '\t' + peerInfo(p)).join('\n') + '\n]'
-                SA.logger.info('peers ' + output)
-            }
+            //function logPeers() {
+            //    const output = thisObject.peers.length == 0 ? '[]' : '[\n' + thisObject.peers.map(p => '\t' + peerInfo(p)).join('\n') + '\n]'
+            //    SA.logger.info('peers ' + output)
+            //}
 
             /* Reschedule execution after connectToPeers() execution finalizes. Not using intervals here to avoid duplicate connections. */
             intervalIdConnectToPeers = setTimeout(connectToPeers, RECONNECT_DELAY)

--- a/Projects/Network/SA/Modules/P2PNetworkNodesConnectedTo.js
+++ b/Projects/Network/SA/Modules/P2PNetworkNodesConnectedTo.js
@@ -31,7 +31,8 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
     function finalize() {
         thisObject.peers = undefined
         clearTimeout(intervalIdConnectToPeers)
-        clearInterval(intervalIdCheckConnectedToPeers)
+        // clearInterval(intervalIdCheckConnectedToPeers)
+        SA.socketLogger.info('finalized P2PNetworkNodesConnectedTo')
     }
 
     async function initialize(
@@ -41,43 +42,50 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
         p2pNetworkClient,
         maxOutgoingPeers
     ) {
-
+        SA.socketLogger.info('initializing P2PNetworkNodesConnectedTo with max outgoing peers ' + maxOutgoingPeers)
         thisObject.peers = []
         connectToPeers()
-        intervalIdCheckConnectedToPeers = setInterval(checkConnectedPeers, HEALTH_CHECK_DELAY)
+        // intervalIdCheckConnectedToPeers = setInterval(checkConnectedPeers, HEALTH_CHECK_DELAY)
 
         async function connectToPeers() {
-
+            logPeers()
             if (thisObject.peers.length >= maxOutgoingPeers) {
                 intervalIdConnectToPeers = setTimeout(connectToPeers, RECONNECT_DELAY)
                 return
             }
-
+            let processedPeers = []
             for (let i = 0; i < p2pNetwork.p2pNodesToConnect.length; i++) {
-                if (thisObject.peers.length >= maxOutgoingPeers) {
-                    break
-                }
+                SA.socketLogger.info('iteration ' + i)
+                // if (thisObject.peers.length >= maxOutgoingPeers) {
+                //     SA.socketLogger.info('breaking from loop due to max peers being met')
+                //     break
+                // }
 
                 let peer = {
                     p2pNetworkNode: undefined,
                     webSocketsClient: undefined
                 }
 
+                // SA.socketLogger.info('init peer object')
                 peer.p2pNetworkNode = p2pNetwork.p2pNodesToConnect[i]
-                if (peer.p2pNetworkNode.node.config.host === undefined) {
+                SA.socketLogger.info('current node is for ' + peerInfo(peer))
+                if (peer.p2pNetworkNode.node.config.host === undefined ) {
+                    // SA.socketLogger.info('host is undefined, moving to next iteration')
                     continue
-
                 } else if (peer.p2pNetworkNode.node.networkInterfaces === undefined) {
+                    // SA.socketLogger.info('networkInterfaces is undefined, moving to next iteration')
                     continue
-
                 } else if (peer.p2pNetworkNode.node.networkInterfaces.websocketsNetworkInterface === undefined) {
+                    // SA.socketLogger.info('websocketsNetworkInterface is undefined, moving to next iteration')
                     continue
-                    
                 } else if (isPeerConnected(peer) === true) {
+                    SA.socketLogger.info('peer is already connected')
                     continue
                 }
+
+                SA.socketLogger.info('initialising websocketClient for ' + peerInfo(peer))
                 peer.webSocketsClient = SA.projects.network.modules.webSocketsNetworkClient.newNetworkModulesWebSocketsNetworkClient()
-                await peer.webSocketsClient.initialize(
+                const task = peer.webSocketsClient.initialize(
                     callerRole,
                     p2pNetworkClientIdentity,
                     peer.p2pNetworkNode,
@@ -86,22 +94,31 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
                 )
                     .then(addPeer)
                     .catch(onError)
-
+                processedPeers.push(task)
+                // automatically add to the peer group then remove is connection is unsuccessful
+                thisObject.peers.push(peer)
+                logPeers()
                 function addPeer() {
-                    thisObject.peers.push(peer)
+                    SA.socketLogger.info('added peer ' + peerInfo(peer))
                     console.log('this is our connected network peers', thisObject.peers)
                 }
 
                 function onError(err) {
-                    if (err !== undefined) {
-                        SA.logger.error('P2P Network Peers -> onError -> While connecting to node -> ' + peer.p2pNetworkNode.userProfile.config.codeName + ' -> ' + peer.p2pNetworkNode.node.name + ' -> ' + err.message)
-                    } else {
-                        /*
-                        DEBUG NOTE: If you are having trouble undestanding why you can not connect to a certain network node, then you can activate the following Console Logs, otherwise you keep them commented out.
-                        */      
-                        //SA.logger.debug           
-                        console.log('P2P Network Peers -> onError -> Peer Not Available at the Moment -> ' + peer.p2pNetworkNode.userProfile.config.codeName + ' -> ' + peer.p2pNetworkNode.node.name)
-                        
+                    SA.socketLogger.error('Peer connection error for ' + peerInfo(peer))
+                    // if (err !== undefined) {
+                    //     SA.logger.error('P2P Network Peers -> onError -> While connecting to node -> ' + peer.p2pNetworkNode.userProfile.config.codeName + ' -> ' + peer.p2pNetworkNode.node.id + ' -> ' + err.message)
+                    // } else {
+                    //     /*
+                    //     DEBUG NOTE: If you are having trouble undestanding why you can not connect to a certain network node, then you can activate the following Console Logs, otherwise you keep them commented out.
+                    //     */      
+                    //     //SA.logger.debug           
+                    //     SA.socketLogger.info('P2P Network Peers -> onError -> Peer Not Available at the Moment -> ' + peer.p2pNetworkNode.userProfile.config.codeName + ' -> ' + peer.p2pNetworkNode.node.id)
+                    // }
+                    const idx = findPeerIndex(peer)
+                    SA.socketLogger.info('peer index is ' + idx)
+                    if(idx > -1) {
+                        SA.socketLogger.info('splicing peers in onError(...)')
+                        thisObject.peers.splice(idx, 1)
                     }
                 }
 
@@ -109,6 +126,7 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
                     for (let i = 0; i < thisObject.peers.length; i++) {
                         let connectedPeer = thisObject.peers[i]
                         if (connectedPeer.webSocketsClient.id === webSocketsClientId) {
+                            SA.socketLogger.info('splicing peers in onConnectionClosed(...)')
                             thisObject.peers.splice(i, 1)
                             return
                         }
@@ -116,13 +134,32 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
                 }
             }
 
+            SA.socketLogger.info('Waiting for all initialization tasks to complete')
+            await Promise.all(processedPeers)
+            SA.socketLogger.info('All initialization tasks completed')
+
             function isPeerConnected(peer) {
+                return findPeerIndex(peer) > -1
+            }
+
+            function findPeerIndex(peer) {
+                SA.socketLogger.info('finding peer ' + peerInfo(peer))
+                logPeers()
                 for (let i = 0; i < thisObject.peers.length; i++) {
-                    let connectedPeer = thisObject.peers[i]
-                    if (connectedPeer.p2pNetworkNode.node.id === peer.p2pNetworkNode.node.id) {
-                        return true
+                    if (thisObject.peers[i].p2pNetworkNode.node.id === peer.p2pNetworkNode.node.id) {
+                        return i
                     }
                 }
+                return -1
+            }
+
+            function peerInfo(peer) {
+                return `name: ${peer.p2pNetworkNode.userProfile.name}, id: ${peer.p2pNetworkNode.node.id}`
+            }
+            
+            function logPeers() {
+                const output = thisObject.peers.length == 0 ? '[]' : '[\n' + thisObject.peers.map(p => '\t' + peerInfo(p)).join('\n') + '\n]'
+                SA.socketLogger.info('peers '+ output)
             }
 
             /* Reschedule execution after connectToPeers() execution finalizes. Not using intervals here to avoid duplicate connections. */
@@ -133,6 +170,7 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
             for (let i = 0; i < thisObject.peers.length; i++) {
                 let peer = thisObject.peers[i]
                 if (peer.webSocketsClient.socketNetworkClients.isConnected !== true) {
+                    SA.socketLogger.info('splicing peers in checkConnectedPeers()')
                     thisObject.peers.splice(i, 1)
                     return
                 }
@@ -192,6 +230,7 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
 
         let response = await peer.webSocketsClient.socketNetworkClients.sendMessage(message, responseHandler)
         if (response.result === 'Error' && response.message === 'Websockets Connection Not Ready.') {
+            SA.socketLogger.info('splicing peers in sendMessage(...)')
             thisObject.peers.splice(peerIndex, 1)
         }
         return response

--- a/Projects/Network/SA/Modules/P2PNetworkNodesConnectedTo.js
+++ b/Projects/Network/SA/Modules/P2PNetworkNodesConnectedTo.js
@@ -157,11 +157,16 @@ exports.newNetworkModulesP2PNetworkNodesConnectedTo = function newNetworkModules
         }
 
         function checkConnectedPeers() {
+            let disconnectedPeers = []
             for (let i = 0; i < thisObject.peers.length; i++) {
                 let peer = thisObject.peers[i]
                 if (peer.webSocketsClient.socketNetworkClients.isConnected !== true) {
-                    thisObject.peers.splice(i, 1)
+                    disconnectedPeers.push(i)
                 }
+            }
+            while (disconnectedPeers.length > 0) {
+                let peer = disconnectedPeer.unshift()
+                thisObject.peers.splice(peer, 1)
             }
         }
     }

--- a/Projects/Network/SA/Modules/P2PNetworkReachableNodes.js
+++ b/Projects/Network/SA/Modules/P2PNetworkReachableNodes.js
@@ -52,8 +52,8 @@ exports.newNetworkModulesP2PNetworkReachableNodes = function newNetworkModulesP2
                                 connectOnlyRequestedToP2pNode = true
                             }
                         }
-                        }
                     }
+                }
                 else {
                     SA.logger.error('The P2P Network Client node is required at each task. Please add the node and try again.')
                 }
@@ -121,8 +121,12 @@ exports.newNetworkModulesP2PNetworkReachableNodes = function newNetworkModulesP2
                 thisObject.p2pNodesToConnect = []
 
                 let thisP2PNodeId = SA.secrets.signingAccountSecrets.map.get(global.env.P2P_NETWORK_NODE_SIGNING_ACCOUNT).nodeId
-                for (let i = 0; i < SA.projects.network.globals.memory.arrays.P2P_NETWORK_NODES.length; i++) {
-                    let p2pNetworkNode = SA.projects.network.globals.memory.arrays.P2P_NETWORK_NODES[i]
+                let nodes = SA.projects.network.utilities.appClientNetworkNodePicker.filteredNetworkNodes(
+                    SA.projects.network.globals.memory.arrays.P2P_NETWORK_NODES,
+                    SA.networkFilters
+                )
+                for (let i = 0; i < nodes.length; i++) {
+                    let p2pNetworkNode = nodes[i]
 
                     if (p2pNetworkNode.node.p2pNetworkReference.referenceParent === undefined) { continue }
                     if (p2pNetworkNode.node.p2pNetworkReference.referenceParent.config === undefined) { continue }

--- a/Projects/Network/SA/Modules/P2PNetworkReachableNodes.js
+++ b/Projects/Network/SA/Modules/P2PNetworkReachableNodes.js
@@ -121,8 +121,12 @@ exports.newNetworkModulesP2PNetworkReachableNodes = function newNetworkModulesP2
                 thisObject.p2pNodesToConnect = []
 
                 let thisP2PNodeId = SA.secrets.signingAccountSecrets.map.get(global.env.P2P_NETWORK_NODE_SIGNING_ACCOUNT).nodeId
-                for (let i = 0; i < SA.projects.network.globals.memory.arrays.P2P_NETWORK_NODES.length; i++) {
-                    let p2pNetworkNode = SA.projects.network.globals.memory.arrays.P2P_NETWORK_NODES[i]
+                let nodes = SA.projects.network.utilities.appClientNetworkNodePicker.filteredNetworkNodes(
+                    SA.projects.network.globals.memory.arrays.P2P_NETWORK_NODES,
+                    SA.networkFilters
+                )
+                for (let i = 0; i < nodes.length; i++) {
+                    let p2pNetworkNode = nodes[i]
 
                     if (p2pNetworkNode.node.p2pNetworkReference.referenceParent === undefined) { continue }
                     if (p2pNetworkNode.node.p2pNetworkReference.referenceParent.config === undefined) { continue }

--- a/Projects/Network/SA/Modules/SocketNetworkClients.js
+++ b/Projects/Network/SA/Modules/SocketNetworkClients.js
@@ -97,7 +97,7 @@ exports.newNetworkModulesSocketNetworkClients = function newNetworkModulesSocket
 
             if (response.result !== 'Ok') {
                 SA.logger.error('Socket Network Clients -> stepOneResponse -> response.message = ' + response.message)
-                reject()
+                reject('Socket Network Clients -> stepOneResponse -> response.message = ' + response.message)
                 return
             }
 
@@ -108,7 +108,7 @@ exports.newNetworkModulesSocketNetworkClients = function newNetworkModulesSocket
             */
             if (called.blockchainAccount === undefined) {
                 SA.logger.error('Socket Network Clients -> stepOneResponse -> Signature does not produce a valid Blockchain Account.')
-                reject()
+                reject('Socket Network Clients -> stepOneResponse -> Signature does not produce a valid Blockchain Account.')
                 return
             }
             /*
@@ -124,7 +124,7 @@ exports.newNetworkModulesSocketNetworkClients = function newNetworkModulesSocket
                 SA.logger.warn('Socket Network Clients -> stepOneResponse -> Not possible to connect to node belonging to ' + thisObject.p2pNetworkNode.userProfile.name)
                 SA.logger.warn('Socket Network Clients -> stepOneResponse -> This error happens when 1) This network node is configured to run on localhost and at localhost you are running your own network node instead. 2) The user profile that owns the Network Node you are connecting to, it is not up-to-date at your machine. Run an app.update to get the latest version of all User Profile plugins and try again. 3) The Network Node you are trying to connect to does not have in memory the latest version of the User Profile Plugin that owns that Network Node. The Network Node updates itself every 5 minutes, so you should wait at least that time and try again.')
                 */
-                reject()
+                reject('blockchainAccounts do not match')
                 return
             }
 
@@ -137,7 +137,7 @@ exports.newNetworkModulesSocketNetworkClients = function newNetworkModulesSocket
             let hash = web3.eth.accounts.hashMessage(signature.message)
             if (hash !== signature.messageHash) {
                 SA.logger.error('Socket Network Clients -> stepOneResponse -> signature.message Hashed Does Not Match signature.messageHash.')
-                reject()
+                reject('Socket Network Clients -> stepOneResponse -> signature.message Hashed Does Not Match signature.messageHash.')
                 return
             }
             /*
@@ -146,7 +146,7 @@ exports.newNetworkModulesSocketNetworkClients = function newNetworkModulesSocket
             */
             if (signedMessage.calledProfileHandle !== thisObject.p2pNetworkNode.userProfile.config.codeName) {
                 SA.logger.error('Socket Network Clients -> stepOneResponse -> The Network Node called does not have the expected Profile codeName.')
-                reject()
+                reject('Socket Network Clients -> stepOneResponse -> The Network Node called does not have the expected Profile codeName.')
                 return
             }
             /*
@@ -155,7 +155,7 @@ exports.newNetworkModulesSocketNetworkClients = function newNetworkModulesSocket
             */
             if (signedMessage.callerProfileHandle !== SA.secrets.signingAccountSecrets.map.get(thisObject.p2pNetworkClientCodeName).userProfileHandle) {
                 SA.logger.error('Socket Network Clients -> stepOneResponse -> The Network Node callerProfileHandle does not match my own userProfileHandle.')
-                reject()
+                reject('Socket Network Clients -> stepOneResponse -> The Network Node callerProfileHandle does not match my own userProfileHandle.')
                 return
             }
             /*
@@ -164,7 +164,7 @@ exports.newNetworkModulesSocketNetworkClients = function newNetworkModulesSocket
             */
             if (signedMessage.callerTimestamp !== callerTimestamp) {
                 SA.logger.error('Socket Network Clients -> stepOneResponse -> The Network Node callerTimestamp does not match my own callerTimestamp.')
-                reject()
+                reject('Socket Network Clients -> stepOneResponse -> The Network Node callerTimestamp does not match my own callerTimestamp.')
                 return
             }
 
@@ -198,7 +198,7 @@ exports.newNetworkModulesSocketNetworkClients = function newNetworkModulesSocket
 
             if (response.result !== 'Ok') {
                 SA.logger.error('Socket Network Clients -> stepOneResponse -> response.message = ' + response.message)
-                reject()
+                reject('Socket Network Clients -> stepOneResponse -> response.message = ' + response.message)
                 return
             }
             /*

--- a/Projects/Network/SA/Modules/WebSocketsNetworkClient.js
+++ b/Projects/Network/SA/Modules/WebSocketsNetworkClient.js
@@ -77,7 +77,16 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
                     clearTimeout(connectionTimeout)
                     SA.socketLogger.info('opened socket connection with '+ hostInfo())
                     heartbeat()
-                    thisObject.socketNetworkClients.handshakeProcedure(resolve, reject)
+                    new Promise((handshakeResolution, handshakeRejection) => thisObject.socketNetworkClients.handshakeProcedure(handshakeResolution, handshakeRejection))
+                        .then(() => resolve())
+                        .catch(err => {
+                            let message = 'handshake rejection'
+                            if(err) {
+                                message = err
+                            }
+                            reject(message)
+                            socket.close()
+                        })
                 }
                 
                 function onConnectionClosed() {
@@ -101,14 +110,13 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
                     if(connectionTimeout !== undefined) {
                         clearTimeout(connectionTimeout)
                     }
-
                     if (err.message.indexOf('ECONNREFUSED') >= 0) {
                         /*
                         DEBUG NOTE: If you are having trouble undestanding why you can not connect to a certain network node, then you can activate the following Console Logs, otherwise you keep them commented out.
                         */ 
                         SA.logger.error('Web Sockets Network Client -> onError -> Nobody home at ' + hostInfo())
                         
-                        reject()
+                        reject('Web Sockets Network Client -> onError -> Nobody home at ' + hostInfo())
                         return
                     } else if (err.message.indexOf('ETIMEDOUT') >= 0) {
                         /*
@@ -116,12 +124,12 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
                         */ 
                         SA.logger.error('Web Sockets Network Client -> onError -> Connection Timed out ' + hostInfo())
                         
-                        reject()
+                        reject('Web Sockets Network Client -> onError -> Connection Timed out ' + hostInfo())
                         return
                     }
                     SA.logger.error('Web Sockets Network Client -> onError -> err.message = ' + err.message)
                     SA.logger.error('Web Sockets Network Client -> onError -> err.stack = ' + err.stack)
-                    reject()
+                    reject('Web Sockets Network Client -> onError -> err.message = ' + err.message)
                     return
                 }
 

--- a/Projects/Network/SA/Modules/WebSocketsNetworkClient.js
+++ b/Projects/Network/SA/Modules/WebSocketsNetworkClient.js
@@ -33,11 +33,11 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
         /*
         DEBUG NOTE: If you are having trouble undestanding why you can not connect to a certain network node, then you can activate the following Console Logs, otherwise you keep them commented out.
         */
-        SA.logger.debug('Websockets Client will try to Connect to Network Node via Web Sockets ........ Trying to Connect to ' + thisObject.p2pNetworkNode.userProfile.config.codeName + ' -> ' + thisObject.p2pNetworkNode.node.name + ' -> ' + thisObject.host + ':' + thisObject.port)
+        SA.logger.debug('Websockets Client will try to Connect to Network Node via Web Sockets ........ Trying to Connect to ' + connectionInfo())
         
 
         let socket = new SA.nodeModules.ws('ws://' + thisObject.host + ':' + thisObject.port)
-
+        SA.socketLogger.info('created socket connection to '+ hostInfo())
         thisObject.socketNetworkClients = SA.projects.network.modules.socketNetworkClients.newNetworkModulesSocketNetworkClients()
         thisObject.socketNetworkClients.initialize(
             socket,
@@ -51,7 +51,7 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
         await setUpWebSocketClient(socket)
 
         SA.logger.info('')
-        SA.logger.info('Websockets Client Connected to Network Node via Web Sockets .................. Connected to ' + thisObject.p2pNetworkNode.userProfile.config.codeName + ' -> ' + thisObject.p2pNetworkNode.node.name + ' -> ' + thisObject.host + ':' + thisObject.port)
+        SA.logger.info('Websockets Client Connected to Network Node via Web Sockets .................. Connected to ' + connectionInfo())
         SA.logger.info('')
         thisObject.socketNetworkClients.isConnected = true
 
@@ -64,22 +64,31 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
         function connectToNewtwork(resolve, reject) {
 
             try {
-
+                // will send a rejection response if this timeout is not cancelled in 30 seconds
+                // the timeout is cancelled by any of the onopen, onclose or onerror functions
+                let connectionTimeout = setTimeout(() => reject('Connection initialization timed out after 30 seconds trying to connect to ' + connectionInfo()), 30000) 
+                
                 socket.onopen = () => { onConnectionOpened() }
                 socket.onclose = () => { onConnectionClosed() }
                 socket.onerror = err => { onError(err) }
                 socket.on('ping', heartbeat)
 
                 function onConnectionOpened() {
+                    clearTimeout(connectionTimeout)
+                    SA.socketLogger.info('opened socket connection with '+ hostInfo())
                     heartbeat()
                     thisObject.socketNetworkClients.handshakeProcedure(resolve, reject)
                 }
-
+                
                 function onConnectionClosed() {
+                    if(connectionTimeout !== undefined) {
+                        clearTimeout(connectionTimeout)
+                    }
+
                     clearTimeout(socket.pingTimeout)
                     if (thisObject.socketNetworkClients.isConnected === true) {
                         SA.logger.info('')
-                        SA.logger.info('Websockets Client Disconnected from Network Node via Web Sockets ............. Disconnected from ' + thisObject.p2pNetworkNode.userProfile.config.codeName + ' -> ' + thisObject.p2pNetworkNode.node.name + ' -> ' + thisObject.host + ':' + thisObject.port)
+                        SA.logger.info('Websockets Client Disconnected from Network Node via Web Sockets ............. Disconnected from ' + connectionInfo())
                         SA.logger.info('')
                     }
                     if (thisObject.onConnectionClosedCallBack !== undefined) {
@@ -87,13 +96,17 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
                     }
                     thisObject.socketNetworkClients.isConnected = false
                 }
-
+                
                 function onError(err) {
+                    if(connectionTimeout !== undefined) {
+                        clearTimeout(connectionTimeout)
+                    }
+
                     if (err.message.indexOf('ECONNREFUSED') >= 0) {
                         /*
                         DEBUG NOTE: If you are having trouble undestanding why you can not connect to a certain network node, then you can activate the following Console Logs, otherwise you keep them commented out.
                         */ 
-                        SA.logger.error('Web Sockets Network Client -> onError -> Nobody home at ' + thisObject.host + ':' + thisObject.port)
+                        SA.logger.error('Web Sockets Network Client -> onError -> Nobody home at ' + hostInfo())
                         
                         reject()
                         return
@@ -101,7 +114,7 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
                         /*
                         DEBUG NOTE: If you are having trouble undestanding why you can not connect to a certain network node, then you can activate the following Console Logs, otherwise you keep them commented out.
                         */ 
-                        SA.logger.error('Web Sockets Network Client -> onError -> Connection Timed out ' + thisObject.host + ':' + thisObject.port)
+                        SA.logger.error('Web Sockets Network Client -> onError -> Connection Timed out ' + hostInfo())
                         
                         reject()
                         return
@@ -116,6 +129,7 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
                 Longer grace period is required due to large Bitcoin Factory files being transferred, this blocking the connection for the ping for a little while. 
                 */
                 function heartbeat() {
+                    SA.socketLogger.info('pinged from '+ hostInfo())
                     clearTimeout(socket.pingTimeout)
                     socket.pingTimeout = setTimeout(() => {
                         SA.logger.info('No Websockets heartbeat received from server, re-initializing connection...')
@@ -127,5 +141,13 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
                 SA.logger.error('Web Sockets Network Client -> setUpWebSocketClient -> err.stack = ' + err.stack)
             }
         }
+    }
+
+    function connectionInfo() {
+        return thisObject.p2pNetworkNode.userProfile.config.codeName + ' -> ' + thisObject.p2pNetworkNode.node.name + ' -> ' + hostInfo()
+    }
+
+    function hostInfo() {
+        return thisObject.host + ':' + thisObject.port
     }
 }

--- a/Projects/Network/SA/Modules/WebSocketsNetworkClient.js
+++ b/Projects/Network/SA/Modules/WebSocketsNetworkClient.js
@@ -33,7 +33,7 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
         /*
         DEBUG NOTE: If you are having trouble undestanding why you can not connect to a certain network node, then you can activate the following Console Logs, otherwise you keep them commented out.
         */
-        SA.logger.debug('Websockets Client will try to Connect to Network Node via Web Sockets ........ Trying to Connect to ' + thisObject.p2pNetworkNode.userProfile.config.codeName + ' -> ' + thisObject.p2pNetworkNode.node.name + ' -> ' + thisObject.host + ':' + thisObject.port)
+        SA.logger.debug('Websockets Client will try to Connect to Network Node via Web Sockets ........ Trying to Connect to ' + connectionInfo())
         
 
         let socket = new SA.nodeModules.ws('ws://' + thisObject.host + ':' + thisObject.port)
@@ -51,7 +51,7 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
         await setUpWebSocketClient(socket)
 
         SA.logger.info('')
-        SA.logger.info('Websockets Client Connected to Network Node via Web Sockets .................. Connected to ' + thisObject.p2pNetworkNode.userProfile.config.codeName + ' -> ' + thisObject.p2pNetworkNode.node.name + ' -> ' + thisObject.host + ':' + thisObject.port)
+        SA.logger.info('Websockets Client Connected to Network Node via Web Sockets .................. Connected to ' + connectionInfo())
         SA.logger.info('')
         thisObject.socketNetworkClients.isConnected = true
 
@@ -64,6 +64,9 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
         function connectToNewtwork(resolve, reject) {
 
             try {
+                // will send a rejection response if this timeout is not cancelled in 30 seconds
+                // the timeout is cancelled by any of the onopen, onclose or onerror functions
+                let connectionTimeout = setTimeout(() => reject('Connection initialization timed out after 30 seconds trying to connect to ' + connectionInfo()), 30000)
 
                 socket.onopen = () => { onConnectionOpened() }
                 socket.onclose = () => { onConnectionClosed() }
@@ -71,15 +74,20 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
                 socket.on('ping', heartbeat)
 
                 function onConnectionOpened() {
+                    clearTimeout(connectionTimeout)
                     heartbeat()
                     thisObject.socketNetworkClients.handshakeProcedure(resolve, reject)
                 }
 
                 function onConnectionClosed() {
+                    if(connectionTimeout !== undefined) {
+                        clearTimeout(connectionTimeout)
+                    }
+
                     clearTimeout(socket.pingTimeout)
                     if (thisObject.socketNetworkClients.isConnected === true) {
                         SA.logger.info('')
-                        SA.logger.info('Websockets Client Disconnected from Network Node via Web Sockets ............. Disconnected from ' + thisObject.p2pNetworkNode.userProfile.config.codeName + ' -> ' + thisObject.p2pNetworkNode.node.name + ' -> ' + thisObject.host + ':' + thisObject.port)
+                        SA.logger.info('Websockets Client Disconnected from Network Node via Web Sockets ............. Disconnected from ' + connectionInfo())
                         SA.logger.info('')
                     }
                     if (thisObject.onConnectionClosedCallBack !== undefined) {
@@ -89,11 +97,15 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
                 }
 
                 function onError(err) {
+                    if(connectionTimeout !== undefined) {
+                        clearTimeout(connectionTimeout)
+                    }
+
                     if (err.message.indexOf('ECONNREFUSED') >= 0) {
                         /*
                         DEBUG NOTE: If you are having trouble undestanding why you can not connect to a certain network node, then you can activate the following Console Logs, otherwise you keep them commented out.
                         */ 
-                        SA.logger.error('Web Sockets Network Client -> onError -> Nobody home at ' + thisObject.host + ':' + thisObject.port)
+                        SA.logger.error('Web Sockets Network Client -> onError -> Nobody home at ' + hostInfo())
                         
                         reject()
                         return
@@ -101,7 +113,7 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
                         /*
                         DEBUG NOTE: If you are having trouble undestanding why you can not connect to a certain network node, then you can activate the following Console Logs, otherwise you keep them commented out.
                         */ 
-                        SA.logger.error('Web Sockets Network Client -> onError -> Connection Timed out ' + thisObject.host + ':' + thisObject.port)
+                        SA.logger.error('Web Sockets Network Client -> onError -> Connection Timed out ' + hostInfo())
                         
                         reject()
                         return
@@ -127,5 +139,13 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
                 SA.logger.error('Web Sockets Network Client -> setUpWebSocketClient -> err.stack = ' + err.stack)
             }
         }
+    }
+
+    function connectionInfo() {
+        return thisObject.p2pNetworkNode.userProfile.config.codeName + ' -> ' + thisObject.p2pNetworkNode.node.name + ' -> ' + hostInfo()
+    }
+
+    function hostInfo() {
+        return thisObject.host + ':' + thisObject.port
     }
 }

--- a/Projects/Network/SA/Modules/WebSocketsNetworkClient.js
+++ b/Projects/Network/SA/Modules/WebSocketsNetworkClient.js
@@ -37,7 +37,7 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
         
 
         let socket = new SA.nodeModules.ws('ws://' + thisObject.host + ':' + thisObject.port)
-        SA.socketLogger.info('created socket connection to '+ hostInfo())
+        // SA.logger.debug('created socket connection to '+ hostInfo())
         thisObject.socketNetworkClients = SA.projects.network.modules.socketNetworkClients.newNetworkModulesSocketNetworkClients()
         thisObject.socketNetworkClients.initialize(
             socket,
@@ -75,7 +75,7 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
 
                 function onConnectionOpened() {
                     clearTimeout(connectionTimeout)
-                    SA.socketLogger.info('opened socket connection with '+ hostInfo())
+                    // SA.logger.debug('opened socket connection with '+ hostInfo())
                     heartbeat()
                     new Promise((handshakeResolution, handshakeRejection) => thisObject.socketNetworkClients.handshakeProcedure(handshakeResolution, handshakeRejection))
                         .then(() => resolve())
@@ -137,7 +137,7 @@ exports.newNetworkModulesWebSocketsNetworkClient = function newNetworkModulesWeb
                 Longer grace period is required due to large Bitcoin Factory files being transferred, this blocking the connection for the ping for a little while. 
                 */
                 function heartbeat() {
-                    SA.socketLogger.info('pinged from '+ hostInfo())
+                    // SA.logger.debug('pinged from '+ hostInfo())
                     clearTimeout(socket.pingTimeout)
                     socket.pingTimeout = setTimeout(() => {
                         SA.logger.info('No Websockets heartbeat received from server, re-initializing connection...')

--- a/Projects/Network/SA/Utilities/AppClientNetworkNodePicker.js
+++ b/Projects/Network/SA/Utilities/AppClientNetworkNodePicker.js
@@ -1,12 +1,128 @@
-exports.newAppClientNetworkNetworkNodePicker = function newAppClientNetworkNetworkNodePicker () {
+exports.newAppClientNetworkNetworkNodePicker = function newAppClientNetworkNetworkNodePicker() {
     let thisObject = {
-        pickOneNetworkNode: pickOneNetworkNode
+        pickOneNetworkNode: pickOneNetworkNode,
+        filteredNetworkNodes: filteredNetworkNodes
     }
+
+    const localhostRegex = /127\.\d+\.\d+\.\d+/
+    const network192Regex = /192\.\d+\.\d+\.\d+/
+    const network10Regex = /10\.\d+\.\d+\.\d+/
+    const network100Regex = /100\.\d+\.\d+\.\d+/
+    const network168Regex = /168\.\d+\.\d+\.\d+/
+    const network172Regex = /172\.\d+\.\d+\.\d+/
 
     return thisObject
 
     function pickOneNetworkNode() {
+    }
 
-        
+    /**
+     * The default will return a list exluding all local network addresses, 
+     * to change this behaviour filters need to be applied
+     * @param {Network[]} p2pNetworkNodes 
+     * @param {Filters | undefined} filters
+     * @returns {Network[]}
+     */
+    function filteredNetworkNodes(p2pNetworkNodes, filters) {
+        const me = whoami()
+        const validNetworkNodes = p2pNetworkNodes.filter(isValidNetworkNode)
+        if(filters !== undefined) {
+            if (filters.onlyMe) {
+                if(filters.includeLocalNetworks !== undefined && !filters.includeLocalNetworks) {
+                    return validNetworkNodes.filter(n => n.userProfile.name == me && !isLocalNetwork(n.node.config.host))
+                }
+                return validNetworkNodes.filter(n => n.userProfile.name == me)
+            }
+            if (filters.users !== undefined && filters.users.length > 0) {
+                const filteredUserNetworks = validNetworkNodes.filter(n => filters.users.indexOf(n.userProfile.name) > -1)
+                if(!!filters.includeLocalNetworks) {
+                    return filteredUserNetworks
+                }
+                return filteredUserNetworks.filter(n => !isLocalNetwork(n.node.config.host))
+            }
+            if(!!filters.includeLocalNetworks) {
+                return validNetworkNodes
+            }
+        }
+        return validNetworkNodes.filter(n => !isLocalNetwork(n.node.config.host))
+    }
+
+    /**
+     * 
+     * @param {NetworkNode | undefined} node 
+     * @returns {boolean}
+     */
+    function isValidNetworkNode(network) {
+        const node = network.node
+        const isValid = node === undefined 
+            || node.config === undefined
+            || node.config.host === undefined
+        return !isValid
+    }
+
+    /**
+     * Tests if the host is part of a local or internal network
+     * 
+     * @param {string} host 
+     * @returns {boolean}
+     */
+    function isLocalNetwork(host) {
+        return host == 'localhost'
+            || localhostRegex.test(host)
+            || network192Regex.test(host)
+            || network10Regex.test(host)
+            || network100Regex.test(host)
+            || network172Regex.test(host)
+            || network168Regex.test(host)
+    }
+
+    /**
+     * @returns {string} current user profile name
+     */
+    function whoami() {
+        try {
+            const rawFile = SA.nodeModules.fs.readFileSync(global.env.PATH_TO_SECRETS + '/githubCredentials.json')
+            const contents = JSON.parse(rawFile)
+            if (contents.githubUsername) {
+                return contents.githubUsername
+            }
+        } catch (_) {
+            // there must be an issue with the github credentials file so we will move on to try the workspace file instead
+        }
+        try {
+            const rawFile = SA.nodeModules.fs.readFileSync(global.env.PATH_TO_SECRETS + '/workspace-credentials.json')
+            const contents = JSON.parse(rawFile)
+            const githubCredentials = contents.filter(x => x.type == 'github')
+            if (githubCredentials.length > 0) {
+                return githubCredentials[0].key
+            }
+        } catch (_) {
+            // there must be an issue with the workspace credentials file we will try something else instead
+        }
+        // TODO: use child process to get git 'origin' remote and decipher the username from this
+        return ''
     }
 }
+
+/**
+ * @typedef Network
+ * @property {{name: string}} userProfile
+ * @property {NetworkNode} node
+ */
+
+/**
+ * @typedef NetworkNode
+ * @property {NetworkNodeConfig | undefined} config
+ */
+
+/**
+ * @typedef NetworkNodeConfig
+ * @property {string | undefined} host
+ */
+
+/**
+ * @typedef Filters
+ * @property {boolean | undefined} includeLocalNetworks 
+ * @property {boolean | undefined} onlyMe defaults to including local network addresses to override specify includesLocalNetworks = false
+ * @property {string[] | undefined} users defaults to excluding local network addresses to override specify includesLocalNetworks = true
+ */

--- a/Projects/Network/SA/Utilities/AppClientNetworkNodePicker.js
+++ b/Projects/Network/SA/Utilities/AppClientNetworkNodePicker.js
@@ -17,7 +17,7 @@ exports.newAppClientNetworkNetworkNodePicker = function newAppClientNetworkNetwo
     }
 
     /**
-     * The default will return a list exluding all local network addresses, 
+     * The default will return a full list including all local network addresses, 
      * to change this behaviour filters need to be applied
      * @param {Network[]} p2pNetworkNodes 
      * @param {Filters | undefined} filters
@@ -40,11 +40,11 @@ exports.newAppClientNetworkNetworkNodePicker = function newAppClientNetworkNetwo
                 }
                 return filteredUserNetworks.filter(n => !isLocalNetwork(n.node.config.host))
             }
-            if(!!filters.includeLocalNetworks) {
-                return validNetworkNodes
+            if(filters.includeLocalNetworks !== undefined && !filters.includeLocalNetworks) {
+                return validNetworkNodes.filter(n => !isLocalNetwork(n.node.config.host))
             }
         }
-        return validNetworkNodes.filter(n => !isLocalNetwork(n.node.config.host))
+        return validNetworkNodes
     }
 
     /**

--- a/Projects/Social-Trading/NT/Modules/Storage.js
+++ b/Projects/Social-Trading/NT/Modules/Storage.js
@@ -94,9 +94,9 @@ exports.newSocialTradingModulesStorage = function newSocialTradingModulesStorage
                 let dataRangeFile = await loadFileFromGithubRepository('Data.Range', '/Nodes/' + p2pNetworkNodeCodeName, userProfileCodeName)
                 SA.logger.info(userProfileCodeName)
                 /*
-                Searching for the node that is most up-to-date
-                */
-               SA.logger.info("IS DATA RANGE FILE UNDEFINED? " + dataRangeFile)
+                 * Searching for the node that is most up-to-date
+                 */
+                SA.logger.info("IS DATA RANGE FILE UNDEFINED? " + dataRangeFile)
                 if (dataRangeFile !== undefined) {
                     if (maxDataRangeEnd < dataRangeFile.end) {
                         maxDataRangeEnd = dataRangeFile.end
@@ -105,8 +105,8 @@ exports.newSocialTradingModulesStorage = function newSocialTradingModulesStorage
                 }
             }
             /*
-            We can not continue if we cannot identify the most up to date node.
-            */
+             * We can not continue if we cannot identify the most up to date node.
+             */
             SA.logger.info("MOST UP TO DATE NETWORK NODE #2 = " + p2pNetworkNodeMostUpToDate)
             if (p2pNetworkNodeMostUpToDate === undefined){
                 return
@@ -116,15 +116,15 @@ exports.newSocialTradingModulesStorage = function newSocialTradingModulesStorage
             */
             if (p2pNetworkNodeMostUpToDate.node.id === thisObject.p2pNetworkNode.node.id) {
                 /*
-                There is no need to update ourselves from some other node because no other
-                is more up-to-date than ourselves.
-                */
+                 * There is no need to update ourselves from some other node because no other
+                 * is more up-to-date than ourselves.
+                 */
                 SA.logger.info("WE ARE THE MOST UP TO DATE NETWORK NODE")
                 return
             }
             /*
-            We will use the node with the most recent history.
-            */
+             * We will use the node with the most recent history.
+             */
             let p2pNetworkNodeCodeName = p2pNetworkNodeMostUpToDate.node.config.codeName
             let userProfileCodeName = p2pNetworkNodeMostUpToDate.userProfile.config.codeName
             SA.logger.info("USER PROFILE MOST UPDATED = " + userProfileCodeName)

--- a/network.js
+++ b/network.js
@@ -11,6 +11,8 @@ USAGE:
     ${chalk.red('node network')} ${chalk.italic.red('[options]')}
         
 OPTIONS:
+    - ${chalk.italic.red('--network-signing-account')} ${chalk.bold.red('text')}
+            A specific P2P network signing account to start using. This overrides the default "P2P-Network-Node-1"
     - ${chalk.italic.red('--include-local-networks')} ${chalk.bold.red('true/false')}
             Do you want to include all local networks nodes?
     - ${chalk.italic.red('--only-me')} ${chalk.bold.red('true/false')}
@@ -19,6 +21,13 @@ OPTIONS:
             Repeat for each username you want to connect to
 
 EXAMPLES:
+
+    ############################################################
+    # To specify a network node on your profile called
+    # ${chalk.italic.red('Local-Network-Node')}
+    ############################################################
+    node network --network-signing-account Local-Network-Node
+
     ############################################################
     # To limit the network connections to only my network nodes, 
     # in order for this to work you will need at least 2 network 
@@ -70,29 +79,42 @@ function buildFilters(args) {
         }
         filters.users = args.users
     }
-    console.log(JSON.stringify(filters))
     return filters
 }
 
 yargs(hideBin(process.argv))
     .version(require('./package.json').version)
     .alias('h', 'help')
-    .command('$0', 'the default command', () => {}, (args) => {
-        let APP_ROOT = require('./NetworkRoot.js')
-        let APP_ROOT_MODULE = APP_ROOT.newNetworkRoot()
-        APP_ROOT_MODULE.run(undefined, buildFilters(args))
+    .command('$0', helpMessage, () => {}, (args) => {
+        if(args.help) {
+            console.log(helpMessage)
+        }
+        else {
+            let APP_ROOT = require('./NetworkRoot.js')
+            let APP_ROOT_MODULE = APP_ROOT.newNetworkRoot()
+            let debugSettings = args.networkSigningAccount === undefined ? undefined : {P2P_NETWORK_NODE_SIGNING_ACCOUNT: args.networkSigningAccount}
+            APP_ROOT_MODULE.run(debugSettings, buildFilters(args))
+        }
     })
     .option('include-local-networks', {
         boolean: true,
         demandOption: false,
+        describe: `To exclude all local networks from the connection pool set the ${chalk.italic.red('--include-local-networks')} to ${chalk.bold.red('false')}. This is useful as  many users will use localhost or a 192 style address when  testing their own network setup and this will create multiple connections self referencing connections.`
     })
     .option('only-me', {
         boolean: true,
         demandOption: false,
+        describe: `To limit the network connections to only my network nodes, in order for this to work you will need at least 2 network nodes setup`
     })
     .option('users', {
         array: true,
         demandOption: false,
+        describe: `To create a network pool with a friend or some specfic users then add as many ${chalk.italic.red('--users <USER>')} options as you need. This will limit the network connection pool to only these user networks.`
     })
-    .help(helpMessage)
+    .option('network-signing-account', {
+        string: true,
+        demandOption: false,
+        describe: `To specify a network node on your profile called ${chalk.bold.red('Local-Network-Node')}`
+    })
+    .help()
     .parse()

--- a/network.js
+++ b/network.js
@@ -8,57 +8,60 @@ const chalk = require('chalk')
 
 const helpMessage = `
 USAGE:
-    ${chalk.red('node network')} ${chalk.italic.red('[options]')}
+${chalk.red('node network')} ${chalk.italic.red('[options]')}
         
 OPTIONS:
-    - ${chalk.italic.red('--network-signing-account')} ${chalk.bold.red('text')}
-            A specific P2P network signing account to start using. This overrides the default "P2P-Network-Node-1"
-    - ${chalk.italic.red('--include-local-networks')} ${chalk.bold.red('true/false')}
-            Do you want to include all local networks nodes?
-    - ${chalk.italic.red('--only-me')} ${chalk.bold.red('true/false')}
-            Do you want to limit the network to only your network nodes?
-    - ${chalk.italic.red('--users')} ${chalk.bold.red('text')}
-            Repeat for each username you want to connect to
+${chalk.italic.red('--network-signing-account')} ${chalk.bold.red('text')}
+A specific P2P network signing account to start using. This overrides the default "P2P-Network-Node-1"
+
+${chalk.italic.red('--include-local-networks')} ${chalk.bold.red('true/false')}
+Do you want to include all local networks nodes?
+
+${chalk.italic.red('--only-me')} ${chalk.bold.red('true/false')}
+Do you want to limit the network to only your network nodes?
+
+${chalk.italic.red('--users')} ${chalk.bold.red('text')}
+Repeat for each username you want to connect to
 
 EXAMPLES:
 
-    ############################################################
-    # To specify a network node on your profile called
-    # ${chalk.italic.red('Local-Network-Node')}
-    ############################################################
-    node network --network-signing-account Local-Network-Node
+############################################################
+# To specify a network node on your profile called
+# ${chalk.italic.red('Local-Network-Node')}
+############################################################
+node network --network-signing-account Local-Network-Node
 
-    ############################################################
-    # To limit the network connections to only my network nodes, 
-    # in order for this to work you will need at least 2 network 
-    # nodes setup
-    ############################################################
-    node network --onlyMe
+############################################################
+# To limit the network connections to only my network nodes, 
+# in order for this to work you will need at least 2 network 
+# nodes setup
+############################################################
+node network --onlyMe
 
-    ############################################################
-    # To exclude all local networks from the connection pool set
-    # the ${chalk.italic.red('--include-local-networks')} to ${chalk.bold.red('false')}. This is useful as 
-    # many users will use localhost or a 192 style address when 
-    # testing their own network setup and this will create
-    # multiple connections self referencing connections.
-    ############################################################
-    node network --include-local-networks false
+############################################################
+# To exclude all local networks from the connection pool set
+# the ${chalk.italic.red('--include-local-networks')} to ${chalk.bold.red('false')}. This is useful as 
+# many users will use localhost or a 192 style address when 
+# testing their own network setup and this will create
+# multiple connections self referencing connections.
+############################################################
+node network --include-local-networks false
 
-    ############################################################
-    # To create a network pool with a friend or some specfic
-    # users then add as many ${chalk.italic.red('--users <USER>')} options as you need.
-    # This will limit the network connection pool to only these
-    # user networks.
-    ############################################################
-    node network --users <USER1> --users <USER2>
-    
-    ############################################################
-    # The options ${chalk.italic.red('--users')} and ${chalk.italic.red('--include-local-networks')} can also
-    # be combined so you do not create duplicate local network
-    # connections. Providing these users are not on your local
-    # network
-    ############################################################
-    node network --users <USER1> --users <USER2> --include-local-networks false
+############################################################
+# To create a network pool with a friend or some specfic
+# users then add as many ${chalk.italic.red('--users <USER>')} options as you need.
+# This will limit the network connection pool to only these
+# user networks.
+############################################################
+node network --users <USER1> --users <USER2>
+
+############################################################
+# The options ${chalk.italic.red('--users')} and ${chalk.italic.red('--include-local-networks')} can also
+# be combined so you do not create duplicate local network
+# connections. Providing these users are not on your local
+# network
+############################################################
+node network --users <USER1> --users <USER2> --include-local-networks false
 `
 function buildFilters(args) {
     let filters = undefined

--- a/network.js
+++ b/network.js
@@ -17,6 +17,9 @@ A specific P2P network signing account to start using. This overrides the defaul
 ${chalk.italic.red('--include-local-networks')} ${chalk.bold.red('true/false')}
 Do you want to include all local networks nodes?
 
+${chalk.italic.red('--exclude-localhost')} ${chalk.bold.red('true/false')}
+Do you want to exclude all localhost and 127.#.#.# nodes?
+
 ${chalk.italic.red('--only-me')} ${chalk.bold.red('true/false')}
 Do you want to limit the network to only your network nodes?
 
@@ -82,6 +85,12 @@ function buildFilters(args) {
         }
         filters.users = args.users
     }
+    if(args.excludeLocalhost !== undefined) {
+        if(filters === undefined) {
+            filters = {}
+        }
+        filters.excludeLocalhost = args.excludeLocalhost
+    }
     return filters
 }
 
@@ -102,7 +111,12 @@ yargs(hideBin(process.argv))
     .option('include-local-networks', {
         boolean: true,
         demandOption: false,
-        describe: `To exclude all local networks from the connection pool set the ${chalk.italic.red('--include-local-networks')} to ${chalk.bold.red('false')}. This is useful as  many users will use localhost or a 192 style address when  testing their own network setup and this will create multiple connections self referencing connections.`
+        describe: `To exclude all local networks from the connection pool set the ${chalk.italic.red('--include-local-networks')} to ${chalk.bold.red('false')}. This is useful as many users will use localhost or a 192 style address when testing their own network setup and this will create multiple connections self referencing connections.`
+    })
+    .option('exclude-localhost', {
+        boolean: true,
+        demandOption: false,
+        describe: `To exclude all localhosts from the connection pool set the ${chalk.italic.red('--exclude-localhost')} to ${chalk.bold.red('true')}. This is useful as many users will use localhost or a 127 style address when testing their own network setup and this will create multiple connections self referencing connections.`
     })
     .option('only-me', {
         boolean: true,


### PR DESCRIPTION
Adding command line options to the network node startup script.

Added ability to create network restrictions on network node for p2p network connections.

Restrictions include the ability to:

- exclude all local network connections
- exclude only localhost connections
- only connect to your own networks
- only connect to a subset of user networks

Added 30 second timeout when initialising a new websocket connection to prevent bottle necks trying to connect to peers.

Resolved increasing number of websocket connections -> the socketNetworkClients.handshakeProcedure was passing through the resolve/reject functions from the parent call which meant the rejections were not getting captured by the websocket and the socket was not getting closed.

Added rejection messages for socket failures.

The max threshold can be crossed as all the tasks run async but on the next iteration if the peers are over the limit they will then be pruned. With the new updates it would be more efficient to user filter to restrict who the network was to connect to instead of a random selection of peers by number.