### PR TITLE
Adding support for Etherscan API keys

### DIFF
--- a/Platform/Client/web3Server.js
+++ b/Platform/Client/web3Server.js
@@ -627,11 +627,6 @@ exports.newWeb3Server = function newWeb3Server() {
                     let gasPrice = 5000000000
                     let gasLimit = 210000
 
-                    if (chain === 'ZKS') {
-                        gasPrice = 25000000
-                        gasLimit = 500000
-                    }
-
                     /* If executing on ETH, verify if current gas price is within reasonable range and calculate price for transaction */
                     if (chain === 'ETH') {
                         /* Maximum gas price in Gwei we are ready to pay */
@@ -679,6 +674,7 @@ exports.newWeb3Server = function newWeb3Server() {
                     result = await web3.eth.sendSignedTransaction('0x' + transaction.serialize().toString('hex'))
                         .catch(err => {
                             SA.logger.error('sendSignedTransaction -> err =' + JSON.stringify(err))
+                            SA.logger.error(err.stack)
                             errorList.push(transactionDetails)
                         })
 

--- a/Projects/Foundations/Schemas/App-Schema/web3-api.json
+++ b/Projects/Foundations/Schemas/App-Schema/web3-api.json
@@ -27,7 +27,7 @@
         "config": true
     },
     "initialValues": {
-        "config": "{ \n\"token\": \"\", \n\"mnemonic\": \"\"\n}"
+        "config": "{ \n\"token\": \"\", \n\"mnemonic\": \"\", \n\"etherscanApiKey\": \"\"\n}"
     },
     "addLeftIcons": true,
     "level": 1,

--- a/Projects/Foundations/Schemas/Docs-Nodes/W/Web3/Web3-API/web3-api.json
+++ b/Projects/Foundations/Schemas/Docs-Nodes/W/Web3/Web3-API/web3-api.json
@@ -1,0 +1,28 @@
+{
+    "type": "Web3 API",
+    "definition": {
+        "text": "The Web3 API node allows to set configuration parameters for Superalgos interaction with blockchains.",
+        "updated": 1730566188251
+    },
+    "paragraphs": [
+        {
+            "style": "Title",
+            "text": "Web3 API configuration",
+            "updated": 1730566336707
+        },
+        {
+            "style": "List",
+            "text": "mnemonic: Used to set wallet access credentials. Only required for the user executing the monthly token distribution.",
+            "updated": 1730566561020
+        },
+        {
+            "style": "List",
+            "text": "etherscanApiKey: Superalgos internally uses Etherscan to obtain information about blockchain transactions. This includes how many SA tokens any given user has received in the past. Past token receipts are used to calculate the user's reputation. Etherscan is not providing this information for free access, but only for registered users with an API Key. At the time of writing, API Keys with sufficient access limits can be obtained for free. To see correct reputation scores, obtain an Etherscan API Key from etherscan.io and enter its value here.",
+            "updated": 1730566794747
+        },
+        {
+            "style": "Text",
+            "text": ""
+        }
+    ]
+}

--- a/Projects/Governance/UI/Spaces/User-Profile-Space/UserProfile.js
+++ b/Projects/Governance/UI/Spaces/User-Profile-Space/UserProfile.js
@@ -165,6 +165,14 @@ function newGovernanceUserProfileSpace() {
                         break
                     case 'ETH':
                         url = "https://api.etherscan.io/api?module=account&action=tokentx&address=" + token["treasuryAccountAddress"] + "&startblock=0"
+                        
+                        /* Etherscan requires API keys. Obtain key from Web3 API node */
+                        let etherscanApiKey
+                        let web3API = UI.projects.workspaces.spaces.designSpace.workspace.getHierarchyHeadsByNodeType('APIs')[0].web3API
+                        etherscanApiKey = UI.projects.visualScripting.utilities.nodeConfig.loadConfigProperty(web3API?.payload, 'etherscanApiKey')
+                        if (etherscanApiKey !== undefined && etherscanApiKey !== "") {
+                            url += "&apikey=" + etherscanApiKey 
+                        }
                         break
                     case 'ZKS':
                         url = "https://block-explorer-api.mainnet.zksync.io/address/" + token["treasuryAccountAddress"] + "/transfers?limit=50"


### PR DESCRIPTION
Aside small updates for distribution transaction cost, this PR will provide a new parameter "etherscanApiKey" under the Web3 node.

It will enable users to enter their personal Etherscan API Keys, leading to correct reputation scores displayed in the Governance workspace.