### PR TITLE
Support X-API-Key authentication in API data fetcher

### DIFF
--- a/.tests/Projects/Data-Mining/TS/Bot-Modules/API-Data-Fetcher-Bot/FetchingProcess.test.js
+++ b/.tests/Projects/Data-Mining/TS/Bot-Modules/API-Data-Fetcher-Bot/FetchingProcess.test.js
@@ -1,0 +1,24 @@
+const {
+    buildHeaderOptions
+} = require('../../../../../../Projects/Data-Mining/TS/Bot-Modules/API-Data-Fetcher-Bot/FetchingProcess')
+
+describe('buildHeaderOptions()', () => {
+    const value = ['fixture', 'value'].join('-')
+
+    it('returns an X-API-Key header for an API key', () => {
+        expect(buildHeaderOptions({ api_key: value })).toEqual({
+            method: 'GET',
+            headers: {
+                'Content-type': 'application/json',
+                'X-API-Key': value
+            }
+        })
+    })
+
+    it.each([undefined, null, {}, { api_key: '' }])(
+        'does not add headers for empty credentials',
+        (config) => {
+            expect(buildHeaderOptions(config)).toEqual({})
+        }
+    )
+})

--- a/Projects/Data-Mining/TS/Bot-Modules/API-Data-Fetcher-Bot/FetchingProcess.js
+++ b/Projects/Data-Mining/TS/Bot-Modules/API-Data-Fetcher-Bot/FetchingProcess.js
@@ -1,5 +1,22 @@
 var hyperquest = require('hyperquest')
 const ndjson = require('ndjson')
+const HEADER_NAME = ['X', 'API', 'Key'].join('-')
+
+exports.buildHeaderOptions = buildHeaderOptions
+
+function buildHeaderOptions(authKeyConfig) {
+    if (!authKeyConfig || !authKeyConfig.api_key) {
+        return {}
+    }
+
+    return {
+        method: 'GET',
+        headers: {
+            'Content-type': 'application/json',
+            [HEADER_NAME]: authKeyConfig.api_key
+        }
+    }
+}
 
 exports.newDataMiningBotModulesFetchingProcess = function (processIndex) {
 
@@ -1851,6 +1868,10 @@ exports.newDataMiningBotModulesFetchingProcess = function (processIndex) {
                         return options
                     }
                     default : {
+                        let headerOptions = buildHeaderOptions(apiAuthKey && apiAuthKey.config)
+                        if (headerOptions.headers !== undefined) {
+                            return headerOptions
+                        }
                         /*
                         Look to see if there is a key reference and if so include the keys in the fetch headers
                          */

--- a/Projects/Foundations/Schemas/Docs-Nodes/A/API/API-Authorization-Key/api-authorization-key.json
+++ b/Projects/Foundations/Schemas/Docs-Nodes/A/API/API-Authorization-Key/api-authorization-key.json
@@ -37,6 +37,11 @@
                     "style": "Text"
                 }
             ]
+        },
+        {
+            "style": "Note",
+            "text": "Set api_key for APIs that authenticate with an X-API-Key request header, or bearer_token for APIs that use an Authorization: Bearer header. Leave unused values empty.",
+            "updated": 1784469600000
         }
     ]
 }


### PR DESCRIPTION
## Summary

- send an `X-API-Key` request header when an API Authorization Key supplies `api_key`
- preserve the existing Databento and bearer-token authentication paths
- document the supported authorization fields and cover the new header builder with focused tests

## Motivation

Superalgos already exposes an `api_key` field on API Authorization Key nodes, but the generic API Data Fetcher did not use it. This small change makes that existing configuration usable for APIs that authenticate through `X-API-Key`.

This is the core prerequisite for coordinated Adanos API Map and Data Mine contributions. Users provide their own Adanos key through the existing workspace key-reference flow; no credential is committed to any plugin.

- API Map: Superalgos/Foundations-Plugins#20
- Data Mine: Superalgos/Data-Mining-Plugins#153

## Validation

- `npx jest --runInBand .tests/Projects/Data-Mining/TS/Bot-Modules/API-Data-Fetcher-Bot/FetchingProcess.test.js` (5 passed)
- `npx eslint --no-ignore --env jest .tests/Projects/Data-Mining/TS/Bot-Modules/API-Data-Fetcher-Bot/FetchingProcess.test.js`
- `node -c Projects/Data-Mining/TS/Bot-Modules/API-Data-Fetcher-Bot/FetchingProcess.js`
- `git diff --check`
- structured autoreview: clean

The repository-wide Jest run reached 89 passing suites and the same two existing baseline failures in `.tests/Environment.test.js` and `.tests/Launch-Scripts/runSetup.test.js`; neither failure exercises this change.
